### PR TITLE
don't abort lvs on softchk fail

### DIFF
--- a/steps/cadence-pegasus-lvs/lvs.runset.template
+++ b/steps/cadence-pegasus-lvs/lvs.runset.template
@@ -9,7 +9,7 @@ lvs_ignore_ports no;
 lvs_expand_cell_on_error no;
 lvs_recognize_gates -none;
 lvs_break_ambig_max 32;
-lvs_abort -softchk yes;
+lvs_abort -softchk no;
 lvs_abort -supply_error yes;
 lvs_find_shorts yes;
 sconnect_upper_shape_count no;


### PR DESCRIPTION
Don't abort LVS on softchk failure because we've found that this can cause false LVS failures. Also brings this lvs node more in line with Calibre LVS node.