### PR TITLE
Bring the naming constraints back

### DIFF
--- a/steps/cadence-genus-synthesis/scripts/read-design.tcl
+++ b/steps/cadence-genus-synthesis/scripts/read-design.tcl
@@ -5,10 +5,13 @@
 # Date   : September 28, 2020
 
 read_hdl -sv [lsort [glob -directory inputs -type f *.v *.sv]]
+
 # Prevent backslashes from being prepended to signal names...
 # this causes SAIF files to be invalid...needs to be before elaboration.
+
 set_attribute hdl_array_naming_style %s_%d
 set_attribute hdl_bus_wire_naming_style %s_%d
 set_attribute bit_blasted_port_style %s_%d /
+
 elaborate $design_name
 

--- a/steps/cadence-genus-synthesis/scripts/read-design.tcl
+++ b/steps/cadence-genus-synthesis/scripts/read-design.tcl
@@ -5,5 +5,10 @@
 # Date   : September 28, 2020
 
 read_hdl -sv [lsort [glob -directory inputs -type f *.v *.sv]]
+# Prevent backslashes from being prepended to signal names...
+# this causes SAIF files to be invalid...needs to be before elaboration.
+set_attribute hdl_array_naming_style %s_%d
+set_attribute hdl_bus_wire_naming_style %s_%d
+set_attribute bit_blasted_port_style %s_%d /
 elaborate $design_name
 


### PR DESCRIPTION
Add in the attribute settings to prevent backslashes from being prepended in post-elab netlist.