### PR TITLE
add rcbest spef to signoff outputs

### DIFF
--- a/steps/cadence-innovus-signoff/configure.yml
+++ b/steps/cadence-innovus-signoff/configure.yml
@@ -28,6 +28,7 @@ outputs:
   - design.sdf
   - design.virtuoso.v
   - design.spef.gz
+  - design.rcbest.spef.gz
 
 #-------------------------------------------------------------------------
 # Commands
@@ -41,6 +42,7 @@ commands:
   - cd outputs
   - ln -sf ../checkpoints/design.checkpoint
   - ln -sf ../typical.spef.gz             design.spef.gz
+  - ln -sf ../rcbest.spef.gz             design.rcbest.spef.gz
   - ln -sf ../results/*.gds.gz            design.gds.gz
   - ln -sf ../results/*-merged.gds        design-merged.gds
   - ln -sf ../results/*.lvs.v             design.lvs.v


### PR DESCRIPTION
Adds rcbest spef as output of signoff to support .lib generation at multiple corners. Even if it's not actually generated, this should be harmless.