### PR TITLE
Synopsys DC Message Suppression

### DIFF
--- a/steps/synopsys-dc-synthesis/configure.yml
+++ b/steps/synopsys-dc-synthesis/configure.yml
@@ -51,6 +51,21 @@ parameters:
   # This is useful for hierarchical LVS when multiple blocks use modules
   # with the same name but different definitions.
   uniquify_with_design_name: True
+  #Enable supression of selected warnings/messages. 
+  suppress_msg: True
+  #List of suppressed messages. Select carefully
+  suppressed_msg:
+    # MW techhnology file load messages abaout missing attributes 
+    - TFCHK-072
+    - TFCHK-014
+    - TFCHK-049
+    - TFCHK-050
+    - TFCHK-012
+    - TFCHK-073
+    - TFCHK-092
+    # orientation warning from MW
+    - PSYN-651
+    - PSYN-650
   # Subscript execute order
   order:
     - designer-interface.tcl

--- a/steps/synopsys-dc-synthesis/configure.yml
+++ b/steps/synopsys-dc-synthesis/configure.yml
@@ -51,9 +51,9 @@ parameters:
   # This is useful for hierarchical LVS when multiple blocks use modules
   # with the same name but different definitions.
   uniquify_with_design_name: True
-  #Enable supression of selected warnings/messages. 
-  suppress_msg: True
-  #List of suppressed messages. Select carefully
+  # Enable supression of selected warnings/messages. 
+  suppress_msg: False
+  # List of suppressed messages. Select carefully
   suppressed_msg:
     # MW techhnology file load messages abaout missing attributes 
     - TFCHK-072

--- a/steps/synopsys-dc-synthesis/scripts/designer-interface.tcl
+++ b/steps/synopsys-dc-synthesis/scripts/designer-interface.tcl
@@ -25,6 +25,8 @@ set dc_num_cores                  $::env(nthreads)
 set dc_high_effort_area_opt       $::env(high_effort_area_opt)
 set dc_gate_clock                 $::env(gate_clock)
 set dc_uniquify_with_design_name  $::env(uniquify_with_design_name)
+set dc_suppress_msg 			  $::env(suppress_msg)
+set dc_suppressed_msg  			  [split $::env(suppressed_msg) ","]
 
 #-------------------------------------------------------------------------
 # Inputs

--- a/steps/synopsys-dc-synthesis/scripts/setup-session.tcl
+++ b/steps/synopsys-dc-synthesis/scripts/setup-session.tcl
@@ -21,6 +21,19 @@ set_host_options -max_cores $dc_num_cores
 set_app_var alib_library_analysis_path $dc_alib_dir
 
 #-------------------------------------------------------------------------
+# Message suppression
+#-------------------------------------------------------------------------
+
+
+if { $dc_suppress_msg } {
+
+  foreach m $dc_suppressed_msg {
+    suppress_message $m
+  }
+
+}
+
+#-------------------------------------------------------------------------
 # Libraries
 #-------------------------------------------------------------------------
 


### PR DESCRIPTION
Added functionality to suppress warning and information messages during the synthesis in the Synopsys Design Compiler step.
For example, loading the technology file results in multiple information messages which are usually not of interest. Some designs may have unconnected ports or nets by design which produce lots of warning messages. This can make the log files hard to read.

Should be used carefully and only after investigating all messages.