### PR TITLE
New Synopsys PrimeTime (PX/PrimePower) power estimation step

### DIFF
--- a/designs/GcdUnit/construct-commercial-full.py
+++ b/designs/GcdUnit/construct-commercial-full.py
@@ -29,6 +29,7 @@ def construct():
     'adk'            : adk_name,
     'adk_view'       : adk_view,
     'topographical'  : True,
+    'saif_instance'  : 'GcdUnitTb/GcdUnit_inst'
   }
 
   #-----------------------------------------------------------------------
@@ -44,7 +45,8 @@ def construct():
 
   # Custom steps
 
-  rtl = Step( this_dir + '/rtl' )
+  rtl       = Step( this_dir + '/rtl' )
+  testbench = Step( this_dir + '/testbench')
 
   # Default steps
 
@@ -66,6 +68,15 @@ def construct():
   drc            = Step( 'mentor-calibre-drc',             default=True )
   lvs            = Step( 'mentor-calibre-lvs',             default=True )
   debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True )
+  vcs_sim        = Step( 'synopsys-vcs-sim',               default=True )
+  power_est      = Step( 'synopsys-pt-power',              default=True )
+
+  #-----------------------------------------------------------------------
+  # Modify Nodes
+  #-----------------------------------------------------------------------
+
+  vcs_sim.extend_inputs(['test_vectors.txt'])
+  vcs_sim.update_params(testbench.params())
 
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
@@ -90,6 +101,9 @@ def construct():
   g.add_step( drc            )
   g.add_step( lvs            )
   g.add_step( debugcalibre   )
+  g.add_step( testbench      )
+  g.add_step( vcs_sim        )
+  g.add_step( power_est      )
 
   #-----------------------------------------------------------------------
   # Graph -- Add edges
@@ -156,6 +170,14 @@ def construct():
   g.connect_by_name( signoff,        debugcalibre   )
   g.connect_by_name( drc,            debugcalibre   )
   g.connect_by_name( lvs,            debugcalibre   )
+
+  g.connect_by_name( adk,            vcs_sim        )
+  g.connect_by_name( signoff,        vcs_sim        )
+  g.connect_by_name( testbench,      vcs_sim        )
+
+  g.connect_by_name( adk,            power_est      )
+  g.connect_by_name( signoff,        power_est      )
+  g.connect_by_name( vcs_sim,        power_est      )
 
   #-----------------------------------------------------------------------
   # Parameterize

--- a/designs/GcdUnit/testbench/GcdUnitTb.sv
+++ b/designs/GcdUnit/testbench/GcdUnitTb.sv
@@ -1,0 +1,64 @@
+`define CLK_PERIOD 20
+`define ASSIGNMENT_DELAY 5
+`define FINISH_TIME 2000000
+`define NUM_TEST_VECTORS 100
+
+module GcdUnitTb;
+  
+  localparam ADDR_WIDTH = $clog2(`NUM_TEST_VECTORS);
+ 
+  reg clk;
+  reg reset;
+  reg [ADDR_WIDTH - 1 : 0] a_b_addr_r;
+  reg [ADDR_WIDTH - 1 : 0] c_addr_r;
+  wire a_b_rdy_w;
+  wire [15 : 0] c_w;
+  wire c_rdy_w;
+
+  reg [16 + 16 + 16 - 1 : 0] test_vectors [`NUM_TEST_VECTORS - 1 : 0];
+
+  always #(`CLK_PERIOD/2) clk =~clk;
+  
+  GcdUnit GcdUnit_inst
+  (
+    .clk(clk),
+    .req_msg(test_vectors[a_b_addr_r][31:0]),
+    .req_rdy(a_b_rdy_w),
+    .req_val(a_b_rdy_w),
+    .reset(reset),
+    .resp_msg(c_w),
+    .resp_rdy(1'b1),
+    .resp_val(c_rdy_w)
+  );
+
+  initial begin
+    $readmemh("inputs/test_vectors.txt", test_vectors);
+    clk <= 0;
+    reset <= 1;
+    a_b_addr_r <= 0;
+    c_addr_r <= 0;
+    #(10*`CLK_PERIOD) reset <= 0;
+  end
+
+  always @ (posedge clk) begin
+    if (!reset && a_b_rdy_w) begin
+      a_b_addr_r <= # `ASSIGNMENT_DELAY (a_b_addr_r + 1); // Don't change the inputs right after the clock edge because that will cause problems in gate level simulation
+    end
+
+    if (c_rdy_w) begin
+      $display("got c = %d, expected c = %d", c_w, test_vectors[c_addr_r][48 - 1 : 32]);
+      assert(c_w == test_vectors[c_addr_r][48 - 1 : 32]);
+      c_addr_r <= c_addr_r + 1;
+      if (c_addr_r == `NUM_TEST_VECTORS - 1) $finish;
+    end
+  end
+
+  initial begin
+    $vcdplusfile("dump.vcd");
+    $vcdplusmemon();
+    $vcdpluson(0, GcdUnitTb);
+    #(`FINISH_TIME);
+    $finish(2);
+  end
+
+endmodule 

--- a/designs/GcdUnit/testbench/configure.yml
+++ b/designs/GcdUnit/testbench/configure.yml
@@ -1,0 +1,17 @@
+# TODO: Set number of vectors parameter in python file and testbench from yml
+
+name: testbench
+
+outputs:
+  - testbench.sv
+  - test_vectors.txt
+  - design.args
+
+parameters:
+  testbench_name: GcdUnitTb
+  dut_name: GcdUnit_inst
+
+commands:
+  - cp GcdUnitTb.sv outputs/testbench.sv
+  - python3 generate_test_vectors.py
+  - cp test_vectors.txt outputs/test_vectors.txt

--- a/designs/GcdUnit/testbench/generate_test_vectors.py
+++ b/designs/GcdUnit/testbench/generate_test_vectors.py
@@ -1,0 +1,23 @@
+from random import random
+import math
+import numpy as np
+import binascii
+import struct
+
+num_vectors = 100
+
+f = open("test_vectors.txt", "w")
+
+def get_hex (x):
+  return str(binascii.hexlify(struct.pack('>H', x)))[2:6] # H is for unsigned short -- 16 bits
+
+i = 0
+
+while (i < num_vectors):
+  a = np.uint16(math.floor(random() * (2**16 - 1)))
+  b = np.uint16(math.floor(random() * (2**16 - 1)))
+  if (a != 0) and (b != 0):
+    c = math.gcd(a, b)
+    f.write(str(get_hex(c)) + '_' + str(get_hex(a)) + '_' + str(get_hex(b)) + '\n') 
+    i = i + 1
+f.close()

--- a/designs/GcdUnit/testbench/outputs/design.args
+++ b/designs/GcdUnit/testbench/outputs/design.args
@@ -1,0 +1,1 @@
+-debug_access+pp +lint=TFIPC-L -lca +neg_tchk -sverilog 

--- a/designs/GcdUnit/testbench/readme.md
+++ b/designs/GcdUnit/testbench/readme.md
@@ -1,0 +1,1 @@
+Testbench of GcdUnit from https://code.stanford.edu/ee272/dnn-accelerator-syn/-/tree/master/GcdUnit/design/testbench

--- a/designs/GcdUnit/testbench/run_tb.sh
+++ b/designs/GcdUnit/testbench/run_tb.sh
@@ -1,0 +1,1 @@
+vcs -full64 -sverilog -timescale=1ns/1ps -debug_access+pp -lca -cflags "-std=c++11" +vc+abstract GcdUnitTb.sv ../rtl/GcdUnit-demo.v

--- a/steps/synopsys-pt-power/START.tcl
+++ b/steps/synopsys-pt-power/START.tcl
@@ -1,0 +1,57 @@
+#=========================================================================
+# START.tcl
+#=========================================================================
+# This script runs a list of other scripts from the "scripts" or "inputs"
+# dir in some order (either default or from an mflowgen Python parameter).
+#
+# The order of the scripts can specified from an mflowgen parameter. This
+# creates a highly flexible node where you can rearrange the internal
+# scripts or add new scripts. For example, with a default order of:
+#
+#     order = step1.tcl step2.tcl step3.tcl
+#
+# After adding a new input called "new.tcl", you can re-parameterize as:
+#
+#     order = step1.tcl new.tcl step2.tcl step3.tcl
+#
+# and the scripts will execute in that order.
+#
+# Author : Christopher Torng
+# Date   : January 14, 2020
+
+#-------------------------------------------------------------------------
+# Execute
+#-------------------------------------------------------------------------
+
+# Order is a comma-separated string containing scripts to run
+
+set order [split $::env(order) ","]
+
+# Run the scripts in order (inputs take priority)
+
+foreach tcl $order {
+  # Try to find the script in the "inputs" directory first
+  if {[ file exists inputs/$tcl ]} {
+    puts "\n  > Info: Sourcing \"inputs/$tcl\"\n"
+    source -echo -verbose inputs/$tcl
+    # Hook to drop into interactive Design Compiler shell after setup
+    if {[ info exists SYN_SETUP_DONE ]} { return }
+  # Try to find the script in the "scripts" directory
+  } elseif {[ file exists scripts/$tcl ]} {
+    puts "\n  > Info: Sourcing \"scripts/$tcl\"\n"
+    source -echo -verbose scripts/$tcl
+    # Hook to drop into interactive Design Compiler shell after setup
+    if {[ info exists SYN_SETUP_DONE ]} { return }
+  # Failed to find the script anywhere...
+  } else {
+    echo "Warn: Did not find $tcl"
+    exit 1
+  }
+}
+
+# Save the primetime session for debug sessions
+save_session outputs/primetime.session
+
+exit
+
+

--- a/steps/synopsys-pt-power/configure.yml
+++ b/steps/synopsys-pt-power/configure.yml
@@ -1,0 +1,65 @@
+#=========================================================================
+# Synopsys PrimePower -- Gate-Level Power Estimation
+#=========================================================================
+# This step runs gate-level average power analysis with Synopsys PrimeTime PX
+# or PrimePower, the successor of the PrimeTime PX feature
+#
+# Both average and time-base power analysis can be done
+# Either gate-level or rtl switching activities can be used
+#
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+#
+
+name: synopsys-pt-power
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+inputs:
+  - adk
+  - design.vcs.v
+  - design.pt.sdc
+  - design.spef.gz
+  - run.saif
+  - run.vcd
+  - design.namemap
+
+outputs:
+  - primetime.session
+  - design.sdf
+
+#-------------------------------------------------------------------------
+# Commands
+#-------------------------------------------------------------------------
+
+commands:
+  - ./run.sh
+
+debug:
+  - ./debug.sh
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+parameters:
+  design_name: undefined
+  #The strip path/ saif_instance must be defined, without any quotations!
+  saif_instance: th/dut
+  # analysis mode either averaged or time_based
+  analysis_mode: averaged
+  # If VCD activity files is the result of a zero-delay simulation, it needs
+  # to be specified! (Otherwise SDF simulation will be assumed)
+  zero_delay_simulation: False
+  # Set library operating condition
+  lib_op_condition: undefined
+  order:
+    - designer-interface.tcl
+    - setup-session.tcl
+    - read-design.tcl
+    - report-timing.tcl
+    - report-power.tcl
+
+

--- a/steps/synopsys-pt-power/debug.sh
+++ b/steps/synopsys-pt-power/debug.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+#=========================================================================
+# debug.sh
+#=========================================================================
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+#
+
+# Print commands during execution
+
+set -x
+
+# Prime Time Shell
+pt_exec='pt_shell'
+
+# Check if a finished session was saved
+if [[ -d ./outputs/primetime.session ]]; then
+	$pt_exec -gui -x "restore_session outputs/primetime.session/" -output_log_file logs/pt.log || exit 1
+else
+	export SYN_EXIT_AFTER_SETUP=1
+	$pt_exec -gui -f "START.tcl" -output_log_file logs/pt.log || exit 1
+fi
+

--- a/steps/synopsys-pt-power/run.sh
+++ b/steps/synopsys-pt-power/run.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+#=========================================================================
+# run.sh
+#=========================================================================
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+#
+
+# Print commands during execution
+
+set -x
+
+# Prime Time Shell
+pt_exec='pt_shell'
+
+# Build directories
+
+rm -rf ./logs
+rm -rf ./reports
+rm -rf ./outputs
+
+mkdir -p logs
+mkdir -p reports
+mkdir -p outputs
+
+$pt_exec -f START.tcl -output_log_file logs/pt.log || exit 1
+
+
+
+
+

--- a/steps/synopsys-pt-power/scripts/designer-interface.tcl
+++ b/steps/synopsys-pt-power/scripts/designer-interface.tcl
@@ -1,0 +1,65 @@
+#=========================================================================
+# designer-interface.tcl
+#=========================================================================
+# The designer_interface.tcl file is the first script run by PT 
+# and sets up ASIC design kit variables and inputs.
+#
+# Author : Christopher Torng
+# Date   : May 20, 2019
+
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+set ptpx_design_name        		$::env(design_name)
+
+# The strip path must be defined!
+#
+#   export strip_path = th/dut
+#
+# There must _not_ be any quotes, or read_saif will fail. This fails:
+#
+#   export strip_path = "th/dut"
+#
+
+set ptpx_strip_path         		$::env(saif_instance)
+
+set ptpx_analysis_mode				$::env(analysis_mode)
+set ptpx_zero_delay_simulation		$::env(zero_delay_simulation)
+set ptpx_op_condition				$::env(lib_op_condition)
+
+#-------------------------------------------------------------------------
+# Libraries
+#-------------------------------------------------------------------------
+
+set adk_dir                       inputs/adk
+
+set ptpx_additional_search_path   $adk_dir
+set ptpx_target_libraries         stdcells.db
+
+set ptpx_extra_link_libraries     [join "
+                                      [glob -nocomplain inputs/*.db]
+                                      [glob -nocomplain inputs/adk/*.db]
+                                  "]
+
+#-------------------------------------------------------------------------
+# Inputs
+#-------------------------------------------------------------------------
+
+set ptpx_gl_netlist         inputs/design.vcs.v
+set ptpx_sdc                inputs/design.pt.sdc
+set ptpx_spef               inputs/design.spef.gz
+set ptpx_saif               inputs/run.saif
+set ptpx_vcd				inputs/run.vcd
+set ptpx_namemap			inputs/design.namemap
+
+#-------------------------------------------------------------------------
+# Directories
+#-------------------------------------------------------------------------
+
+set ptpx_reports_dir	   	reports
+set ptpx_logs_dir	   		logs
+set ptpx_outputs_dir		outputs
+
+

--- a/steps/synopsys-pt-power/scripts/read-design.tcl
+++ b/steps/synopsys-pt-power/scripts/read-design.tcl
@@ -1,0 +1,71 @@
+#=========================================================================
+# read-design.tcl
+#=========================================================================
+# This script reads in all the input files
+#
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+
+# Read and link the design
+
+read_verilog   $ptpx_gl_netlist
+current_design $ptpx_design_name
+
+link_design > ${ptpx_logs_dir}/${ptpx_design_name}.link.rpt
+
+# Namemapping for RTL switching activities
+
+if { $ptpx_rtl_mapping == True } {
+	echo "Sourcing RTL name mapping file for RTL switching activity annotation."
+	source $ptpx_namemap -echo > ${ptpx_logs_dir}/${ptpx_design_name}.namemap.rpt
+}
+
+# Read in switching activity
+
+if {$ptpx_analysis_mode == "time_based" || $ptpx_averaged_use_activity == "vcd"} {
+	report_activity_file_check $ptpx_vcd -strip_path $ptpx_strip_path \
+		> $ptpx_reports_dir/$ptpx_design_name.activity.pre.rpt
+
+	if { $ptpx_rtl_mapping == True } {
+		echo "Read VCD activity annotation file from RTL simulation."
+		read_vcd -strip_path $ptpx_strip_path -rtl $ptpx_vcd 
+	} else {
+		if {$ptpx_zero_delay_simulation == True} {
+			echo "Read VCD activity annotation file from zero-delay simulation."
+			read_vcd -strip_path $ptpx_strip_path -zero_delay $ptpx_vcd 
+		} else {
+			echo "Read VCD activity annotation file from SDF annotated simulation."
+			read_vcd -strip_path $ptpx_strip_path $ptpx_vcd 
+		}
+		
+	}
+	
+} else {
+	report_activity_file_check $ptpx_saif -strip_path $ptpx_strip_path \
+		> $ptpx_reports_dir/$ptpx_design_name.activity.pre.rpt
+
+	echo "Read SAIF activity annotation file."
+	read_saif -strip_path $ptpx_strip_path $ptpx_saif
+}
+
+# Read SDC file
+
+read_sdc -echo $ptpx_sdc > ${ptpx_logs_dir}/${ptpx_design_name}.read_sdc.rpt
+
+# Read parsitics file
+
+read_parasitics -format spef $ptpx_spef
+report_annotated_parasitics -check \
+  > $ptpx_reports_dir/$ptpx_design_name.parasitics.rpt
+
+# Set operating condition in case mutliple libraries are loaded
+
+if {$ptpx_op_condition != "undefined"} {
+	set_operating_condition $ptpx_op_condition
+} else {
+	echo "No operating condition is defined. PrimeTime will choose one."
+}
+
+
+# This is the entry point for the debug view
+if {[info exists ::env(SYN_EXIT_AFTER_SETUP)]} { set SYN_SETUP_DONE true }

--- a/steps/synopsys-pt-power/scripts/report-power.tcl
+++ b/steps/synopsys-pt-power/scripts/report-power.tcl
@@ -1,0 +1,60 @@
+#=========================================================================
+# report-power.tcl
+#=========================================================================
+# This script checks for potential errors, performs power analysis and
+# reports the power of the design
+#
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+
+
+# Check for potential problems for power analysis
+
+check_power > $ptpx_reports_dir/$ptpx_design_name.power.check.rpt
+
+# Set power analysis options
+
+if {$ptpx_analysis_mode == "time_based"} {
+	
+	# Set some analysis options for peak power analysis over time:
+	# -include all hierarchy cells, except for leaf cells
+	# - report worst peak power phases in final report
+	# - save waveform as FSDB in the reports directory 
+	set_power_analysis_options 	-include all_without_leaf \
+								-npeak 10 -peak_power_instances \
+								-npeak_out $ptpx_reports_dir/$ptpx_design_name \
+								-waveform_output $ptpx_reports_dir/$ptpx_design_name
+} 
+
+# Apply activiy annotations and calculate power values
+
+update_power > $ptpx_logs_dir/$ptpx_design_name.power.update.rpt
+
+#-------------------------------------------------------------------------
+# Power Reports
+#-------------------------------------------------------------------------
+
+# Report switching activity
+report_switching_activity \
+  > $ptpx_reports_dir/$ptpx_design_name.activity.post.rpt
+
+# Group-based power report
+report_power -nosplit -verbose \
+  > $ptpx_reports_dir/$ptpx_design_name.power.rpt
+
+# Cell hierarchy power report
+report_power -nosplit -hierarchy -verbose \
+  > $ptpx_reports_dir/$ptpx_design_name.power.hier.rpt
+
+report_clock_gate_savings  > $ptpx_reports_dir/$ptpx_design_name.clock-gate-savings.rpt
+
+# Get Leakage for each used library and count of cells
+
+foreach_in_collection l [get_libs] {
+	if {[get_attribute [get_lib $l] default_threshold_voltage_group] == ""} {
+	    set libname [get_object_name [get_lib $l]]
+	    set_user_attribute [get_lib $l] default_threshold_voltage_group $libname -class lib
+	}
+}
+report_power -threshold_voltage_group > $ptpx_reports_dir/$ptpx_design_name.power.leakage-per-lib.rpt
+report_threshold_voltage_group > $ptpx_reports_dir/$ptpx_design_name.power.cells-per-vth-group.rpt

--- a/steps/synopsys-pt-power/scripts/report-timing.tcl
+++ b/steps/synopsys-pt-power/scripts/report-timing.tcl
@@ -1,0 +1,49 @@
+#=========================================================================
+# report-timing.tcl
+#=========================================================================
+# This script checks for potential errors, performs timing analysis and
+# reports the timing of the design
+#
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+
+# Check for potential errors in timing
+check_timing > $ptpx_reports_dir/$ptpx_design_name.timing.check.rpt
+
+# Perform timing analysis
+update_timing -full > $ptpx_logs_dir/$ptpx_design_name.timing.update.rpt
+
+# Report path timings, clocks, constraints violations, ...
+
+report_global_timing > $ptpx_reports_dir/$ptpx_design_name.timing.global.rpt
+
+report_clock -skew -attribute > $ptpx_reports_dir/$ptpx_design_name.timing.clocks.rpt 
+
+report_analysis_coverage > $ptpx_reports_dir/$ptpx_design_name.timing.analysiscoverage.rpt
+
+report_constraints -all_violators -verbose > $ptpx_reports_dir/$ptpx_design_name.timing.constraints.rpt
+
+report_design > $ptpx_reports_dir/$ptpx_design_name.design.rpt
+
+report_net > $ptpx_reports_dir/$ptpx_design_name.net.rpt
+
+# Setup timing report
+
+report_timing -delay max \
+	-slack_lesser_than 1.0 -max_paths 1000 -sort_by slack \
+	-input -net -crosstalk_delta -nosplit -capacitance -transition_time \
+	-pba_mode exhaustive \
+	> $ptpx_reports_dir/$ptpx_design_name.timing.setup.rpt
+
+# Hold timing report
+# (Slack result is inverted. Positive slack means hold timing met...)
+
+report_timing -delay min \
+	-slack_lesser_than 1.0 -max_paths 1000 -sort_by slack \
+	-input -net -crosstalk_delta -nosplit -capacitance -transition_time \
+	-pba_mode exhaustive \
+	> $ptpx_reports_dir/$ptpx_design_name.timing.hold.rpt
+
+# Write delay file
+
+write_sdf -significant_digits 6  $ptpx_outputs_dir/design.sdf

--- a/steps/synopsys-pt-power/scripts/setup-session.tcl
+++ b/steps/synopsys-pt-power/scripts/setup-session.tcl
@@ -1,0 +1,57 @@
+#=========================================================================
+# setup-session.tcl
+#=========================================================================
+# The setup session script configures the PrimteTime session to use
+# PT PX or PrimePower to do power analysis
+#
+# Author : Maximilian Koschay
+# Date   : 05.03.2021
+
+
+# Set up paths and libraries
+
+set_app_var search_path      ". $ptpx_additional_search_path $search_path"
+set_app_var target_library   $ptpx_target_libraries
+set_app_var link_library     [join "
+                               *
+                               $ptpx_target_libraries
+                               $ptpx_extra_link_libraries
+                             "]
+
+# Set up power analysis
+
+set_app_var power_enable_analysis true
+set_app_var power_analysis_mode   $ptpx_analysis_mode
+
+set_app_var report_default_significant_digits 3
+
+# check if GL or RTL activity file is used by checking the existence of
+# a namemap file
+
+if {[file exists $ptpx_namemap] == 1} {
+	set ptpx_rtl_mapping True
+} else {
+	set ptpx_rtl_mapping False
+}
+
+# check if requireed activity file exist
+
+if {$ptpx_analysis_mode == "time_based"} {
+	if {[file exists $ptpx_vcd] == 0} {
+		echo "Error: Did not find a value change dumb file for time-based power analysis!"
+    	exit 1
+	} 
+} elseif {$ptpx_analysis_mode == "averaged"} {
+	if {[file exists $ptpx_saif] == 1} {
+		set ptpx_averaged_use_activity "saif"
+	} elseif { [file exists $ptpx_vcd] == 1 } {
+		set ptpx_averaged_use_activity "vcd"
+	} else {
+		echo "Error: Did not find a VCD or SAIF file for averaged power analysis!"
+    	exit 1
+	}
+
+} else {
+	echo "Error: analysis_mode must be set either averaged or time_based!"
+	exit 1
+}

--- a/steps/synopsys-vcs-sim/configure.yml
+++ b/steps/synopsys-vcs-sim/configure.yml
@@ -38,7 +38,7 @@ inputs:
 # the waveform parameter to False.
 
 outputs:
-  - design.vpd
+  - run.vcd
 
 #-------------------------------------------------------------------------
 # Commands
@@ -52,6 +52,6 @@ commands:
 #-------------------------------------------------------------------------
 
 parameters:
-  clock_period: 1.0
   testbench_name: tb
+  dut_name: dut
   waveform: True

--- a/steps/synopsys-vcs-sim/run.sh
+++ b/steps/synopsys-vcs-sim/run.sh
@@ -6,13 +6,14 @@ ARGS="$ARGS -hsopt"
 
 # Dump waveform
 if [ "$waveform" = "True" ]; then
-    ARGS="$ARGS +vcs+dumpvars+outputs/design.vpd"
+    ARGS="$ARGS +vcs+dumpvars+outputs/run.vcd"
 fi
 
 # ADK for GLS
-if [ -d "inputs/adk" ]; then
-    ARGS="$ARGS inputs/adk/stdcells.v"
-fi
+for f in inputs/adk/*.v; do
+    [ -e "$f" ] || continue
+    ARGS="$ARGS $f"
+done
 
 # Set-up testbench
 ARGS="$ARGS -top $testbench_name"
@@ -27,6 +28,11 @@ for f in inputs/*.sv; do
     [ -e "$f" ] || continue
     ARGS="$ARGS $f"
 done
+
+if [ -a "inputs/design.sdf" ]; then
+  ARGS="$ARGS +sdfverbose -sdf typ:${testbench_name}.${dut_name}:inputs/design.sdf"
+fi
+
 
 # Optional arguments
 if [ -f "inputs/design.args" ]; then


### PR DESCRIPTION
This new node is essentially a replacement for the 'synopsys-ptpx-gl' and 'synopsys-ptpx-rtl' power estimation steps.
It allows using activity annotation from both GL and RTL simulation, provided either as SAIF or VCD file.
Using a VCD file also allows time_based analysis, which can be switched to using a configuration parameter.
The node also includes extensive timing analysis, similar to the 'synopsys-pt-timing-signoff' node.

The new node uses the Sub-node design pattern, allowing to replace single steps, such as the design_interface.
A debug command allows to start the GUI during or after a successful run to use the visualization features for PrimeTime.

Moreover following nodes have been modified or added:
- synopsys-vcs-sim
  - changed outputs name from design.vpd to run.vcd to unify the naming conventions on the typically following steps
  - added parameter 'dut_name' to enable strip path / saif instance name generation for SDF imports
  - added optional SDF import
  - changed ADK setup to include all .db library files from the ADK
  
- GcdUnit demo testbench
  - added the GcdUnit testbench, imported from <https://code.stanford.edu/ee272/dnn-accelerator-syn/-/tree/master/GcdUnit/design/testbench>
  - the testbench can be used with the VCS simulation step for both RTL and GL simulation
  - added an GL simulation and power estimation step to the full commercial flow

- synopsys-ptpx-gl and synopsys-ptpx-rtl could essentially be removed (not committed)
