### PR TITLE
Synopsys Formality step for formal verification 

### DIFF
--- a/designs/GcdUnit/construct-commercial-full.py
+++ b/designs/GcdUnit/construct-commercial-full.py
@@ -70,6 +70,7 @@ def construct():
   debugcalibre   = Step( 'cadence-innovus-debug-calibre',  default=True )
   vcs_sim        = Step( 'synopsys-vcs-sim',               default=True )
   power_est      = Step( 'synopsys-pt-power',              default=True )
+  formal_verif   = Step( 'synopsys-formality-verification', default=True )
 
   #-----------------------------------------------------------------------
   # Modify Nodes
@@ -77,6 +78,11 @@ def construct():
 
   vcs_sim.extend_inputs(['test_vectors.txt'])
   vcs_sim.update_params(testbench.params())
+
+  verif_post_synth = formal_verif.clone()
+  verif_post_synth.set_name('verif_post_synth')
+  verif_post_layout = formal_verif.clone()
+  verif_post_layout.set_name('verif_post_layout')
 
   #-----------------------------------------------------------------------
   # Graph -- Add nodes
@@ -104,6 +110,8 @@ def construct():
   g.add_step( testbench      )
   g.add_step( vcs_sim        )
   g.add_step( power_est      )
+  g.add_step( verif_post_synth )
+  g.add_step( verif_post_layout )
 
   #-----------------------------------------------------------------------
   # Graph -- Add edges
@@ -178,6 +186,16 @@ def construct():
   g.connect_by_name( adk,            power_est      )
   g.connect_by_name( signoff,        power_est      )
   g.connect_by_name( vcs_sim,        power_est      )
+
+  g.connect_by_name( adk,            verif_post_synth )
+  g.connect_by_name( dc,             verif_post_synth )
+  g.connect( rtl.o('design.v'), verif_post_synth.i('design.ref.v') )
+  g.connect( dc.o('design.v'), verif_post_synth.i('design.impl.v') )
+
+  g.connect_by_name( adk,            verif_post_layout )
+  g.connect_by_name( dc,             verif_post_layout )
+  g.connect( dc.o('design.v'), verif_post_layout.i('design.ref.v') )
+  g.connect( signoff.o('design.lvs.v'), verif_post_layout.i('design.impl.v') )
 
   #-----------------------------------------------------------------------
   # Parameterize

--- a/steps/synopsys-dc-synthesis/configure.yml
+++ b/steps/synopsys-dc-synthesis/configure.yml
@@ -21,6 +21,7 @@ outputs:
   - design.v
   - design.sdc
   - design.namemap
+  - design.svf
 
 #-------------------------------------------------------------------------
 # Commands

--- a/steps/synopsys-dc-synthesis/run.sh
+++ b/steps/synopsys-dc-synthesis/run.sh
@@ -89,6 +89,7 @@ ln -sf ../results/*.mapped.v       design.v
 ln -sf ../results/*.mapped.sdc     design.sdc
 ln -sf ../results/*.mapped.spef.gz design.spef.gz
 ln -sf ../reports/*.namemap        design.namemap
+ln -sf ../results/*.svf            design.svf
 
 cd ..
 

--- a/steps/synopsys-formality-verification/START.tcl
+++ b/steps/synopsys-formality-verification/START.tcl
@@ -1,0 +1,52 @@
+#=========================================================================
+# START.tcl
+#=========================================================================
+# This script runs a list of other scripts from the "scripts" or "inputs"
+# dir in some order (either default or from an mflowgen Python parameter).
+#
+# The order of the scripts can specified from an mflowgen parameter. This
+# creates a highly flexible node where you can rearrange the internal
+# scripts or add new scripts. For example, with a default order of:
+#
+#     order = step1.tcl step2.tcl step3.tcl
+#
+# After adding a new input called "new.tcl", you can re-parameterize as:
+#
+#     order = step1.tcl new.tcl step2.tcl step3.tcl
+#
+# and the scripts will execute in that order.
+#
+# Author : Christopher Torng
+# Date   : January 14, 2020
+
+#-------------------------------------------------------------------------
+# Execute
+#-------------------------------------------------------------------------
+
+# Order is a comma-separated string containing scripts to run
+
+set order [split $::env(order) ","]
+
+# Run the scripts in order (inputs take priority)
+
+foreach tcl $order {
+  # Try to find the script in the "inputs" directory first
+  if {[ file exists inputs/$tcl ]} {
+    puts "\n  > Info: Sourcing \"inputs/$tcl\"\n"
+    source -echo -verbose inputs/$tcl
+  # Try to find the script in the "scripts" directory
+  } elseif {[ file exists scripts/$tcl ]} {
+    puts "\n  > Info: Sourcing \"scripts/$tcl\"\n"
+    source -echo -verbose scripts/$tcl
+  # Failed to find the script anywhere...
+  } else {
+    echo "Warn: Did not find $tcl"
+    exit 1
+  }
+}
+
+# Save the fm session for debug
+save_session fm_session
+
+exit
+

--- a/steps/synopsys-formality-verification/configure.yml
+++ b/steps/synopsys-formality-verification/configure.yml
@@ -1,0 +1,70 @@
+#=========================================================================
+# Synopsys Formality -- Formal Verification
+#=========================================================================
+# This step runs formal verification with Synopsys Formality. This step
+# proves the equivalence of two designs: the reference design and the
+# implemented design. The main purpose is to find any issues that may
+# have been created during the implemenation process.
+#
+# In general, this step should be run twice: 
+# - RTL (reference) vs. post-synthesis netlist (implementation)
+# - Post-synthesis netlist (reference) vs. post-layout netlist (implementation)
+#
+# Author : Kartik Prabhu
+# Date   : March 23, 2021
+
+name: synopsys-formality-verification
+
+#-------------------------------------------------------------------------
+# Inputs and Outputs
+#-------------------------------------------------------------------------
+
+inputs:
+  - adk
+  - design.ref.v
+  - design.ref.upf
+  - design.impl.v
+  - design.impl.upf
+  - design.svf
+
+#-------------------------------------------------------------------------
+# Commands
+#-------------------------------------------------------------------------
+
+commands:
+  - source run.sh
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+parameters:
+  design_name: undefined
+  # Multithreading available to the tool
+  nthreads: 8
+  # Order of script execution
+  order:
+    - designer-interface.tcl
+    - setup-session.tcl
+    - read-design.tcl
+    - verify.tcl
+
+#-------------------------------------------------------------------------
+# Debug
+#-------------------------------------------------------------------------
+
+debug: 
+  - fm_shell -gui -session fm_session.fss
+
+#-------------------------------------------------------------------------
+# Assertions
+#-------------------------------------------------------------------------
+
+postconditions:
+  
+  # Check for no failing compare points
+  - |
+    import glob
+    with open(glob.glob('reports/*.failing_points.rpt')[0], 'r') as f:
+      text = f.read()
+    assert "No failing compare points." in text

--- a/steps/synopsys-formality-verification/run.sh
+++ b/steps/synopsys-formality-verification/run.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+#=========================================================================
+# run.sh
+#=========================================================================
+# Author : Kartik Prabhu
+# Date   : March 23, 2021
+#
+
+# Print commands during execution
+
+set -x
+
+# Build directories
+
+rm -rf ./logs
+rm -rf ./reports
+
+mkdir -p logs
+mkdir -p reports
+
+
+fm_shell -f START.tcl | tee -i logs/fm.log

--- a/steps/synopsys-formality-verification/scripts/designer-interface.tcl
+++ b/steps/synopsys-formality-verification/scripts/designer-interface.tcl
@@ -1,0 +1,50 @@
+#=========================================================================
+# designer-interface.tcl
+#=========================================================================
+# The designer_interface.tcl file is the first script run by FM 
+# and sets up ASIC design kit variables and inputs.
+#
+# Author : Kartik Prabhu
+# Date   : March 23, 2021
+
+
+#-------------------------------------------------------------------------
+# Parameters
+#-------------------------------------------------------------------------
+
+set fm_design_name        		$::env(design_name)
+set fm_num_cores                $::env(nthreads)
+
+#-------------------------------------------------------------------------
+# Libraries
+#-------------------------------------------------------------------------
+
+set adk_dir                       inputs/adk
+
+set fm_additional_search_path   $adk_dir
+
+set fm_extra_link_libraries     [join "
+                                      [glob -nocomplain inputs/*.db]
+                                      [glob -nocomplain inputs/adk/*.db]
+                                  "]
+
+#-------------------------------------------------------------------------
+# Inputs
+#-------------------------------------------------------------------------
+
+set fm_ref_design           inputs/design.ref.v
+set fm_ref_upf              inputs/design.ref.upf
+
+set fm_impl_design          inputs/design.impl.v
+set fm_impl_upf             inputs/design.impl.upf
+
+set fm_svf                  inputs/design.svf
+
+#-------------------------------------------------------------------------
+# Directories
+#-------------------------------------------------------------------------
+
+set fm_reports_dir	   	reports
+set fm_logs_dir	   		logs
+
+

--- a/steps/synopsys-formality-verification/scripts/read-design.tcl
+++ b/steps/synopsys-formality-verification/scripts/read-design.tcl
@@ -1,0 +1,30 @@
+#=========================================================================
+# read-design.tcl
+#=========================================================================
+# This script reads in all the input files.
+#
+# Author : Kartik Prabhu
+# Date   : March 23, 2021
+
+set_svf $fm_svf
+
+read_db $fm_extra_link_libraries
+
+# Load reference design
+read_verilog -r $fm_ref_design
+
+if {[ file exists $fm_ref_upf ]} {
+    load_upf $fm_ref_upf
+}
+
+set_top $fm_design_name
+
+
+# Load implemented design
+read_verilog -i $fm_impl_design
+
+if {[ file exists $fm_impl_upf ]} {
+    load_upf $fm_impl_upf
+}
+
+set_top $fm_design_name

--- a/steps/synopsys-formality-verification/scripts/setup-session.tcl
+++ b/steps/synopsys-formality-verification/scripts/setup-session.tcl
@@ -1,0 +1,17 @@
+#=========================================================================
+# setup-session.tcl
+#=========================================================================
+# The setup session script configures the Formality session to analyze 
+# clock gating and sets other variables.
+#
+# Author : Kartik Prabhu
+# Date   : March 23, 2021
+
+# Multicore support
+set_host_options -max_cores $fm_num_cores 
+
+# Specifies that the design has both low and high styles of clock gating
+set_app_var verification_clock_gate_hold_mode any
+
+# Reduce the simulation-synthesis mismatch message to a warning
+set_mismatch_message_filter -warn

--- a/steps/synopsys-formality-verification/scripts/verify.tcl
+++ b/steps/synopsys-formality-verification/scripts/verify.tcl
@@ -1,0 +1,24 @@
+#=========================================================================
+# verify.tcl
+#=========================================================================
+# This script creates match compare points and verification.
+#
+# Author : Kartik Prabhu
+# Date   : March 23, 2021
+
+# Creates compare points to match objects between the reference and 
+# implementation designs.
+match
+
+# Check this report to see what points were not matched
+report_unmatched_points > ${fm_reports_dir}/$fm_design_name.unmatched.rpt
+
+# Prove equivalence
+verify > ${fm_reports_dir}/$fm_design_name.verif.rpt
+
+# Points that were found to not be functionally equivalent
+report_failing_points > ${fm_reports_dir}/$fm_design_name.failing_points.rpt
+# Points that were not found to be passing or failing
+report_aborted_points > ${fm_reports_dir}/$fm_design_name.aborted_points.rpt
+# Points that were not verified (usually as a result of too many failing points)
+report_unverified_points > ${fm_reports_dir}/$fm_design_name.unverified_points.rpt


### PR DESCRIPTION
This step performs formal verification to prove the equivalence between a reference design and an implemented design. This can be used to verify that no bugs were introduced in the implementation process.

I've also modified the DC step in order to output the svf file so that it can be connected by name to the Formality step.

To demonstrate the usage of this step, I've modified the construct script for GcdUnit to verify the equivalence between the RTL, post-synthesis netlist, and post-layout netlist.