### PR TITLE
fixing worst-case lib loads

### DIFF
--- a/steps/cadence-genus-genlib/scripts/set_libs.tcl
+++ b/steps/cadence-genus-genlib/scripts/set_libs.tcl
@@ -6,11 +6,6 @@
 # Author : Stephen Richardson
 # Date   : December 2020
 
-# FIXME Note similar code in nearby scripts, maybe they should all share a common code base
-#     cadence-innovus-flowsetup/setup.tcl
-#     cadence-genus-synthesis/scripts/designer-interface.tcl
-#     cadence-genus-synthesis/scripts/setup-session.tcl
-
 set vars(adk_dir) inputs/adk
 
 #-------------------------------------------------------------------------

--- a/steps/cadence-genus-genlib/scripts/set_libs.tcl
+++ b/steps/cadence-genus-genlib/scripts/set_libs.tcl
@@ -6,8 +6,7 @@
 # Author : Stephen Richardson
 # Date   : December 2020
 
-# Note similar code in nearby scripts
-# FIXME maybe they should all share a common code base
+# FIXME Note similar code in nearby scripts, maybe they should all share a common code base
 #     cadence-innovus-flowsetup/setup.tcl
 #     cadence-genus-synthesis/scripts/designer-interface.tcl
 #     cadence-genus-synthesis/scripts/setup-session.tcl
@@ -36,7 +35,7 @@ foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
 # - Voltage: highest
 # - Temperature: highest (temperature inversion at 28nm and below)
 # FIXME note this code repeats all the bc libraries in the list at
-# least twice, because of the extra '*-bc-*' pattern...
+# least twice, because of the extra '*-bc-*' pattern...is this intentional?
 
 if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
     set vars(libs_bc,timing) \
@@ -59,12 +58,14 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 # - Process: ss
 # - Voltage: lowest
 # - Temperature: lowest (temperature inversion at 28nm and below)
-# FIXME is there a reason this only looks for iocells???
 
 if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
     set vars(libs_wc,timing) \
         [join "
             $vars(adk_dir)/stdcells-wc.lib
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
             [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
             [lsort [glob -nocomplain inputs/*ss*.lib]]
             [lsort [glob -nocomplain inputs/*SS*.lib]]

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -46,11 +46,6 @@ if { $gate_clock == True } {
 # existing step 'cadence-innovus-flowsetup/setup.tcl'
 #
 # Also, added "lsort" to "glob" for better determinacy.
-#
-# FIXME Note similar code in nearby scripts, maybe they should all share a common code base
-#     cadence-innovus-flowsetup/setup.tcl
-#     cadence-genus-synthesis/scripts/designer-interface.tcl
-#     cadence-genus-synthesis/scripts/setup-session.tcl
 
 global vars
 set vars(adk_dir) inputs/adk

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -46,6 +46,11 @@ if { $gate_clock == True } {
 # existing step 'cadence-innovus-flowsetup/setup.tcl'
 #
 # Also, added "lsort" to "glob" for better determinacy.
+#
+# FIXME Note similar code in nearby scripts, maybe they should all share a common code base
+#     cadence-innovus-flowsetup/setup.tcl
+#     cadence-genus-synthesis/scripts/designer-interface.tcl
+#     cadence-genus-synthesis/scripts/setup-session.tcl
 
 global vars
 set vars(adk_dir) inputs/adk
@@ -101,6 +106,9 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
     set vars(libs_wc,timing) \
         [join "
             $vars(adk_dir)/stdcells-wc.lib
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
             [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
             [lsort [glob -nocomplain inputs/*ss*.lib]]
             [lsort [glob -nocomplain inputs/*SS*.lib]]

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -71,11 +71,6 @@ set vars(dbs_dir)             checkpoints
 source $vars(adk_dir)/adk.tcl
 
 # Library sets
-# 
-# FIXME Note similar code in nearby scripts, maybe they should all share a common code base
-#     cadence-innovus-flowsetup/setup.tcl
-#     cadence-genus-synthesis/scripts/designer-interface.tcl
-#     cadence-genus-synthesis/scripts/setup-session.tcl
 
 set vars(library_sets)        "libs_typical"
 
@@ -115,8 +110,6 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 # - Voltage: lowest
 # - Temperature: lowest (temperature inversion at 28nm and below)
 
-# FIXME/TODO all the globs (above and below) should be lsort'ed for better
-# determinacy; but I will save that for a separate branch fix on some later day...
 if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
   set vars(libs_wc,timing)    [join "
                                 $vars(adk_dir)/stdcells-wc.lib

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -71,6 +71,11 @@ set vars(dbs_dir)             checkpoints
 source $vars(adk_dir)/adk.tcl
 
 # Library sets
+# 
+# FIXME Note similar code in nearby scripts, maybe they should all share a common code base
+#     cadence-innovus-flowsetup/setup.tcl
+#     cadence-genus-synthesis/scripts/designer-interface.tcl
+#     cadence-genus-synthesis/scripts/setup-session.tcl
 
 set vars(library_sets)        "libs_typical"
 
@@ -113,6 +118,9 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
   set vars(libs_wc,timing)    [join "
                                 $vars(adk_dir)/stdcells-wc.lib
+                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
+                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
+                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
                                 [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]
                                 [glob -nocomplain inputs/*ss*.lib]
                                 [glob -nocomplain inputs/*SS*.lib]

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -115,6 +115,8 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 # - Voltage: lowest
 # - Temperature: lowest (temperature inversion at 28nm and below)
 
+# FIXME/TODO all the globs (above and below) should be lsort'ed for better
+# determinacy; but I will save that for a separate branch fix on some later day...
 if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
   set vars(libs_wc,timing)    [join "
                                 $vars(adk_dir)/stdcells-wc.lib


### PR DESCRIPTION
Added lvt, ulvt, and pm libraries to worst-case lib list, to match similar code for typical- and best-case loads, also see Issue https://github.com/mflowgen/mflowgen/issues/102