### PR TITLE
LVS postcondition

### DIFF
--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -101,5 +101,5 @@ preconditions:
 
 postconditions:
 
-  - assert '#     INCORRECT     #' not in File( 'lvs.report' )
+  - "assert '#     INCORRECT     #' not in File( 'lvs.report' )"
 

--- a/steps/mentor-calibre-lvs/configure.yml
+++ b/steps/mentor-calibre-lvs/configure.yml
@@ -99,4 +99,7 @@ preconditions:
   - assert File( 'inputs/design_merged.gds' )
   - assert File( 'inputs/design.lvs.v' )
 
+postconditions:
+
+  - assert '#     INCORRECT     #' not in File( 'lvs.report' )
 


### PR DESCRIPTION
As described in mflowgen issue https://github.com/mflowgen/mflowgen/issues/106 , the existing mflowgen LVS step exits with zero (good) status regardless of whether LVS passed or failed. This change fixes that. I have tested the change with both passing and failing LVS test rigs, and it seems to work, see e.g. https://buildkite.com/tapeout-aha/fullchip/builds/247

Also see
* Garnet pull https://github.com/StanfordAHA/garnet/pull/778
* Mflowgen issue https://github.com/mflowgen/mflowgen/issues/106
