### PR TITLE
Prevent silent fail of mflowgen-run scripts

### DIFF
--- a/mflowgen/core/build_orchestrator.py
+++ b/mflowgen/core/build_orchestrator.py
@@ -680,6 +680,8 @@ N. For a completely clean build, run the "clean-all" target.\n''' )
       postcond_script = meta_build_dir + '/' + s.mflowgen_postcond
 
       commands = ' && '.join([
+        # FIRST set pipefail so we get correct error status at the end
+        'set -o pipefail',
         # Step banner in big letters
         get_top_dir() \
             + '/mflowgen/scripts/mflowgen-letters -c -t ' + step_name,


### PR DESCRIPTION
In its current state, mflowgen produces Makefile sequences that look something like
```
  # BAD sequence does not trigger error-1 when mflowgen-run fails
  mflowgen-run 2>&1 | tee mflowgen-run.log || exit 1
```
This sequence never reaches the `exit 1` command because, although the `mflowgen-run` command in the first half of the pipeline might fail, the `tee` command in the second half of the pipeline always succeeds, so the pipeline overall never fails.

The corrected sequence below fails if any pipestage fails, as was originally intended:
```
  # GOOD sequence triggers error-1 when mflowgen-run fails
  set -o pipefail && mflowgen-run 2>&1 | tee mflowgen-run.log || exit 1
```
See garnet issue https://github.com/StanfordAHA/garnet/issues/791 and garnet pull https://github.com/StanfordAHA/garnet/pull/792 to see how we use this change to fix a long-standing garnet bug.
