### PR TITLE
Placement check

### DIFF
--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
@@ -19,17 +19,3 @@ source $vars(adk_dir)/adk.tcl
 # there is always a reports directory.
 
 mkdir -p $vars(rpt_dir)
-
-# [08/2021] There seems to be a source of nondeterminism when
-# building e.g. garnet glb tile. Also see garnet issue
-# https://github.com/StanfordAHA/garnet/issues/803
-# 
-# 
-#   **WARN: (IMPECO-560): The netlist is not unique, because the module
-#   'Tile_PE_mux_logic_1_20' is instantiated multiple times. Make the
-#   netlist unique by running 'set init_design_uniquify 1' before
-#   loading the design to avoid the problem.
-#
-# So...
-
-set init_design_uniquify 1

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
@@ -20,3 +20,16 @@ source $vars(adk_dir)/adk.tcl
 
 mkdir -p $vars(rpt_dir)
 
+# [steveri 08/2021] There seems to be a source of nondeterminism when
+# building e.g. garnet glb tile:
+# 
+# **WARN: (IMPECO-560): The netlist is not unique, because the module
+#   'Tile_PE_mux_logic_1_20' is instantiated multiple times. Make the
+#   netlist unique by running 'set init_design_uniquify 1' before
+#   loading the design to avoid the problem.
+# 
+# Type 'man IMPECO-560' for more detail.
+#
+# So...
+
+set init_design_uniquify 1

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
@@ -20,15 +20,13 @@ source $vars(adk_dir)/adk.tcl
 
 mkdir -p $vars(rpt_dir)
 
-# [steveri 08/2021] There seems to be a source of nondeterminism when
+# [08/2021] There seems to be a source of nondeterminism when
 # building e.g. garnet glb tile:
 # 
-# **WARN: (IMPECO-560): The netlist is not unique, because the module
+#   **WARN: (IMPECO-560): The netlist is not unique, because the module
 #   'Tile_PE_mux_logic_1_20' is instantiated multiple times. Make the
 #   netlist unique by running 'set init_design_uniquify 1' before
 #   loading the design to avoid the problem.
-# 
-# Type 'man IMPECO-560' for more detail.
 #
 # So...
 

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/always-source.tcl
@@ -21,7 +21,9 @@ source $vars(adk_dir)/adk.tcl
 mkdir -p $vars(rpt_dir)
 
 # [08/2021] There seems to be a source of nondeterminism when
-# building e.g. garnet glb tile:
+# building e.g. garnet glb tile. Also see garnet issue
+# https://github.com/StanfordAHA/garnet/issues/803
+# 
 # 
 #   **WARN: (IMPECO-560): The netlist is not unique, because the module
 #   'Tile_PE_mux_logic_1_20' is instantiated multiple times. Make the

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/route-design-check.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/route-design-check.tcl
@@ -1,0 +1,18 @@
+#=========================================================================
+# route-design-check.tcl
+#=========================================================================
+# This plug-in script replaces the default "routeDesign" command in
+# Innovus flow scripts, activated via this var in setup.tcl
+#   `set vars(route,route_design,replace_tcl) <path>/route-design-check.tcl`
+#
+# Author : Stephen Richardson
+# Date   : September 1, 2021
+
+# FAIL routeDesign immediately if placement is bad.
+# Also see garnet issue https://github.com/StanfordAHA/garnet/issues/803
+# 
+# ANECDOTE: without the "-placementCheck" switch in the routing step,
+# glb_tile CI build went into postroute_hold with bad placement and was still
+# grinding 122 hours later (takes less than one hour with correct placement).
+
+routeDesign -placementCheck

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -401,13 +401,15 @@ set vars(route,restore_design,skip)             true
 set vars(postroute,restore_design,skip)         true
 set vars(signoff,restore_design,skip)           true
 
-# [steveri Aug 2021] FAIL routeDesign immediately if placement is bad.
-# METHOD: replace "routeDesign" w/ "routeDesign -placementCheck" in run_route.tcl
-# ANECDOTE: without this new "-placementCheck" switch, glb_tile build
+# [Aug 2021] FAIL routeDesign immediately if placement is bad.
+# 
+# ANECDOTE: without the "-placementCheck" switch, glb_tile CI build
 # went into postroute_hold with bad placement and was still runnning
 # after 122 hours (takes less than one hour with correct placement).
+# 
+# METHOD: Create and point to a tmp file containing the command that
+# will replace "routeDesign"
 
-# Create a tmp file containing the command that will replace "routeDesign"
 set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
 set tmpf [open $tmp_rrdrt w]
 puts $tmpf "routeDesign -placementCheck"; close $tmpf

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -407,8 +407,6 @@ set vars(signoff,restore_design,skip)           true
 # went into postroute_hold with bad placement and was still runnning
 # after 122 hours (takes less than one hour with correct placement).
 
-set vars(route,check_place,skip) false
-
 set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
 set tmpf [open $tmp_rrdrt w]
 puts $tmpf "routeDesign -placementCheck"; close $tmpf

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -402,6 +402,7 @@ set vars(postroute,restore_design,skip)         true
 set vars(signoff,restore_design,skip)           true
 
 # [Aug 2021] FAIL routeDesign immediately if placement is bad.
+# Also see garnet issue https://github.com/StanfordAHA/garnet/issues/803
 # 
 # ANECDOTE: without the "-placementCheck" switch, glb_tile CI build
 # went into postroute_hold with bad placement and was still runnning

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -555,6 +555,13 @@ if { $::env(skip_verify_connectivity) } {
   set vars(signoff,verify_connectivity,skip) true
 }
 
+# [steveri Aug 2021] FAIL routeDesign if placement is bad.
+# Anecdote: without this new "-placementCheck" switch, glb_tile build
+# went into postroute_hold with bad placement and was still runnning
+# after 122 hours (takes less than one hour with correct placement).
+
+set vars(route,route_design) "routeDesign -placementCheck"
+
 #-------------------------------------------------------------------------
 # Reduced-effort flow that sacrifices timing to iterate more quickly
 #-------------------------------------------------------------------------

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -408,7 +408,7 @@ set vars(signoff,restore_design,skip)           true
 # after 122 hours (takes less than one hour with correct placement).
 
 set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
-set tmpf [open $tmp_rrdt w]
+set tmpf [open $tmp_rrdrt w]
 puts $tmpf "routeDesign -placementCheck"; close $tmpf
 set vars(route,route_design,replace_tcl) $tmp_rrdrt
 

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -401,7 +401,7 @@ set vars(route,restore_design,skip)             true
 set vars(postroute,restore_design,skip)         true
 set vars(signoff,restore_design,skip)           true
 
-# [steveri Aug 2021] FAIL routeDesign if placement is bad.
+# [steveri Aug 2021] FAIL routeDesign immediately if placement is bad.
 # METHOD: replace "routeDesign" w/ "routeDesign -placementCheck" in run_route.tcl
 # ANECDOTE: without this new "-placementCheck" switch, glb_tile build
 # went into postroute_hold with bad placement and was still runnning

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -408,7 +408,8 @@ set vars(signoff,restore_design,skip)           true
 # after 122 hours (takes less than one hour with correct placement).
 
 set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
-echo "routeDesign -placementCheck"     > $tmp_rrdrt
+set tmpf [open $tmp_rrdt w]
+puts $tmpf "routeDesign -placementCheck"; close $tmpf
 set vars(route,route_design,replace_tcl) $tmp_rrdrt
 
 # Custom GDS stream out tcl

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -407,6 +407,8 @@ set vars(signoff,restore_design,skip)           true
 # went into postroute_hold with bad placement and was still runnning
 # after 122 hours (takes less than one hour with correct placement).
 
+set vars(route,check_place,skip) false
+
 set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
 set tmpf [open $tmp_rrdrt w]
 puts $tmpf "routeDesign -placementCheck"; close $tmpf

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -401,6 +401,16 @@ set vars(route,restore_design,skip)             true
 set vars(postroute,restore_design,skip)         true
 set vars(signoff,restore_design,skip)           true
 
+# [steveri Aug 2021] FAIL routeDesign if placement is bad.
+# METHOD: replace "routeDesign" w/ "routeDesign -placementCheck" in run_route.tcl
+# ANECDOTE: without this new "-placementCheck" switch, glb_tile build
+# went into postroute_hold with bad placement and was still runnning
+# after 122 hours (takes less than one hour with correct placement).
+
+set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
+echo "routeDesign -placementCheck"     > $tmp_rrdrt
+set vars(route,route_design,replace_tcl) $tmp_rrdrt
+
 # Custom GDS stream out tcl
 
 set vars(gds_layer_map)                       $vars(adk_dir)/rtk-stream-out.map
@@ -554,13 +564,6 @@ set vars(tags,verbosity_level)         high
 if { $::env(skip_verify_connectivity) } {
   set vars(signoff,verify_connectivity,skip) true
 }
-
-# [steveri Aug 2021] FAIL routeDesign if placement is bad.
-# Anecdote: without this new "-placementCheck" switch, glb_tile build
-# went into postroute_hold with bad placement and was still runnning
-# after 122 hours (takes less than one hour with correct placement).
-
-set vars(route,route_design) "routeDesign -placementCheck"
 
 #-------------------------------------------------------------------------
 # Reduced-effort flow that sacrifices timing to iterate more quickly

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -401,20 +401,9 @@ set vars(route,restore_design,skip)             true
 set vars(postroute,restore_design,skip)         true
 set vars(signoff,restore_design,skip)           true
 
-# [Aug 2021] FAIL routeDesign immediately if placement is bad.
-# Also see garnet issue https://github.com/StanfordAHA/garnet/issues/803
-# 
-# ANECDOTE: without the "-placementCheck" switch, glb_tile CI build
-# went into postroute_hold with bad placement and was still runnning
-# after 122 hours (takes less than one hour with correct placement).
-# 
-# METHOD: Create and point to a tmp file containing the command that
-# will replace "routeDesign"
+# Replace "routeDesign" command with contents of "route-design-check.tcl"
 
-set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
-set tmpf [open $tmp_rrdrt w]
-puts $tmpf "routeDesign -placementCheck"; close $tmpf
-set vars(route,route_design,replace_tcl) $tmp_rrdrt
+set vars(route,route_design,replace_tcl)      $vars(custom_scripts_dir)/route-design-check.tcl
 
 # Custom GDS stream out tcl
 

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -407,6 +407,7 @@ set vars(signoff,restore_design,skip)           true
 # went into postroute_hold with bad placement and was still runnning
 # after 122 hours (takes less than one hour with correct placement).
 
+# Create a tmp file containing the command that will replace "routeDesign"
 set tmp_rrdrt $vars(custom_scripts_dir)/route,route_design,replace_tcl.tcl
 set tmpf [open $tmp_rrdrt w]
 puts $tmpf "routeDesign -placementCheck"; close $tmpf

--- a/steps/cadence-innovus-init/scripts/main.tcl
+++ b/steps/cadence-innovus-init/scripts/main.tcl
@@ -6,6 +6,7 @@
 # Author : Christopher Torng
 # Date   : January 13, 2020
 
+set init_design_uniquify 1
 source -verbose innovus-foundation-flow/INNOVUS/run_init.tcl
 
 


### PR DESCRIPTION
See garnet issue https://github.com/StanfordAHA/garnet/issues/791.

The problem is that the mflowgen `route` step can fail silently, causing seemingly-unrelated problems later in the pipeline, problems that are then difficult to track down. (See e.g. https://buildkite.com/tapeout-aha/fullchip/builds/276, canceled after 6 days of computation.)

Specifically, if placement errors occur before/during routing, a warning is issued but, other than that, no error is flagged. In the case of garnet flow (again see issue https://github.com/StanfordAHA/garnet/issues/791), the error eventually showed up only when the user eventually noticed that the later `postroute_hold` step failed to close timing even after computing for a Very Long Time.

The proposed change in this pull modifies `flowsetup`, replacing the default `routeDesign` command with `routeDesign -placementCheck`, which throws an error in case of bad placement, instead of simply issuing a warning that gets lost in the log.

ALSO SEE:
* garnet issue https://github.com/StanfordAHA/garnet/issues/791
* mflowgen pull https://github.com/mflowgen/mflowgen/pull/111
* garnet pull https://github.com/StanfordAHA/garnet/pull/801
