### PR TITLE
Pt signoff reports

### DIFF
--- a/designs/GcdUnit/construct-commercial-full.py
+++ b/designs/GcdUnit/construct-commercial-full.py
@@ -63,6 +63,7 @@ def construct():
   postroute      = Step( 'cadence-innovus-postroute',      default=True )
   postroute_hold = Step( 'cadence-innovus-postroute_hold', default=True )
   signoff        = Step( 'cadence-innovus-signoff',        default=True )
+  pt_signoff     = Step( 'synopsys-pt-timing-signoff',     default=True )
   genlibdb       = Step( 'synopsys-ptpx-genlibdb',         default=True )
   gdsmerge       = Step( 'mentor-calibre-gdsmerge',        default=True )
   drc            = Step( 'mentor-calibre-drc',             default=True )
@@ -102,6 +103,7 @@ def construct():
   g.add_step( postroute      )
   g.add_step( postroute_hold )
   g.add_step( signoff        )
+  g.add_step( pt_signoff     )
   g.add_step( genlibdb       )
   g.add_step( gdsmerge       )
   g.add_step( drc            )
@@ -130,6 +132,7 @@ def construct():
   g.connect_by_name( adk,            postroute      )
   g.connect_by_name( adk,            postroute_hold )
   g.connect_by_name( adk,            signoff        )
+  g.connect_by_name( adk,            pt_signoff        )
   g.connect_by_name( adk,            gdsmerge       )
   g.connect_by_name( adk,            drc            )
   g.connect_by_name( adk,            lvs            )
@@ -162,6 +165,8 @@ def construct():
   g.connect_by_name( postroute,      postroute_hold )
   g.connect_by_name( postroute_hold, signoff        )
 
+  g.connect_by_name( signoff,        pt_signoff     )
+  
   g.connect_by_name( signoff,        genlibdb       )
   g.connect_by_name( adk,            genlibdb       )
 

--- a/steps/synopsys-pt-timing-signoff/configure.yml
+++ b/steps/synopsys-pt-timing-signoff/configure.yml
@@ -27,6 +27,7 @@ outputs:
 #-------------------------------------------------------------------------
 
 commands:
+  - mkdir -p reports
   - pt_shell -file pt.tcl
   - mkdir -p outputs && cd outputs
   - ln -sf ../design.sdf design.sdf

--- a/steps/synopsys-pt-timing-signoff/pt.tcl
+++ b/steps/synopsys-pt-timing-signoff/pt.tcl
@@ -9,22 +9,23 @@ set report_default_significant_digits 3
 ##################################################################
 #    Constraint Analysis Section
 ##################################################################
-check_constraints -verbose > check_constraints.report
+check_constraints -verbose > reports/check_constraints.report
 
 ##################################################################
 #    Update_timing and check_timing Section                      #
 ##################################################################
 
 update_timing -full
-check_timing -verbose > check_timing.report
+check_timing -verbose > reports/check_timing.report
 
 ##################################################################
 #    Report_timing Section                                       #
 ##################################################################
-report_global_timing > report_global_timing.report
-report_clock -skew -attribute > report_clock.report 
-report_analysis_coverage > report_analysis_coverage.report
-report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay min_max -nosplit -input -net > report_timing_pba.report
+report_global_timing > reports/report_global_timing.report
+report_clock -skew -attribute > reports/report_clock.report 
+report_analysis_coverage > reports/report_analysis_coverage.report
+report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay max -nosplit -input -net -transition_time > reports/report_timing_setup_pba.report
+report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay min -nosplit -input -net -transition_time -path_type full_clock_expanded > reports/report_timing_hold_pba.report
 
 write_sdf -significant_digits 6 design.sdf
 

--- a/steps/synopsys-pt-timing-signoff/pt.tcl
+++ b/steps/synopsys-pt-timing-signoff/pt.tcl
@@ -1,3 +1,12 @@
+#=========================================================================
+# reporting.tcl
+#=========================================================================
+# Final reports
+#
+# Author : Alex Carsello
+# Date   : November 15, 2021
+#
+
 source -echo -verbose scripts/read_design.tcl
 
 # Please do not modify the sdir variable.
@@ -16,16 +25,43 @@ check_constraints -verbose > reports/check_constraints.report
 ##################################################################
 
 update_timing -full
+
 check_timing -verbose > reports/check_timing.report
 
 ##################################################################
 #    Report_timing Section                                       #
 ##################################################################
 report_global_timing > reports/report_global_timing.report
+
 report_clock -skew -attribute > reports/report_clock.report 
+
 report_analysis_coverage > reports/report_analysis_coverage.report
-report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay max -nosplit -input -net -transition_time -path_type full_clock_expanded > reports/report_timing_setup_pba.report
-report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay min -nosplit -input -net -transition_time -path_type full_clock_expanded > reports/report_timing_hold_pba.report
+
+report_timing \
+  -crosstalk_delta \
+  -slack_lesser_than 1000.0 \
+  -max_paths 100 \
+  -pba_mode exhaustive \
+  -delay max \
+  -nosplit \
+  -input \
+  -net \
+  -transition_time \
+  -path_type full_clock_expanded \
+  > reports/report_timing_setup_pba.report
+
+report_timing \
+  -crosstalk_delta \
+  -slack_lesser_than 1000.0 \
+  -max_paths 100 \
+  -pba_mode exhaustive \
+  -delay min \
+  -nosplit \
+  -input \
+  -net \
+  -transition_time \
+  -path_type full_clock_expanded \
+  > reports/report_timing_hold_pba.report
 
 write_sdf -significant_digits 6 design.sdf
 

--- a/steps/synopsys-pt-timing-signoff/pt.tcl
+++ b/steps/synopsys-pt-timing-signoff/pt.tcl
@@ -48,7 +48,7 @@ report_timing \
   -net \
   -transition_time \
   -path_type full_clock_expanded \
-  > reports/report_timing_setup_pba.report
+  > reports/$::env(design_name).timing.setup.rpt
 
 report_timing \
   -crosstalk_delta \
@@ -61,7 +61,7 @@ report_timing \
   -net \
   -transition_time \
   -path_type full_clock_expanded \
-  > reports/report_timing_hold_pba.report
+  > reports/$::env(design_name).timing.hold.rpt
 
 write_sdf -significant_digits 6 design.sdf
 

--- a/steps/synopsys-pt-timing-signoff/pt.tcl
+++ b/steps/synopsys-pt-timing-signoff/pt.tcl
@@ -24,7 +24,7 @@ check_timing -verbose > reports/check_timing.report
 report_global_timing > reports/report_global_timing.report
 report_clock -skew -attribute > reports/report_clock.report 
 report_analysis_coverage > reports/report_analysis_coverage.report
-report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay max -nosplit -input -net -transition_time > reports/report_timing_setup_pba.report
+report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay max -nosplit -input -net -transition_time -path_type full_clock_expanded > reports/report_timing_setup_pba.report
 report_timing -crosstalk_delta -slack_lesser_than 1000.0 -max_paths 100 -pba_mode exhaustive -delay min -nosplit -input -net -transition_time -path_type full_clock_expanded > reports/report_timing_hold_pba.report
 
 write_sdf -significant_digits 6 design.sdf


### PR DESCRIPTION
Small quality of life improvements for pt-timing-signoff node.

-Create separate setup and hold reports, rather than one combined report
-Include full clock paths in both reports
-Include transition times in both reports
-Organizes all reports into reports folder

Also adds pt-timing signoff to gcd flow.