### PR TITLE
Skip welltap insertion if welltap cells not present in adk

### DIFF
--- a/steps/cadence-innovus-init/scripts/add-endcaps-welltaps.tcl
+++ b/steps/cadence-innovus-init/scripts/add-endcaps-welltaps.tcl
@@ -4,15 +4,19 @@
 # Author : Christopher Torng
 # Date   : March 4, 2020
 
-# Add well taps
+# Add well taps if ADK contains well taps
 
-addWellTap -cell [list $ADK_WELL_TAP_CELL] \
-           -prefix       WELLTAP \
-           -cellInterval $ADK_WELL_TAP_INTERVAL \
-           -checkerboard
-
-verifyWellTap -cells [list $ADK_WELL_TAP_CELL] \
-              -report reports/welltap.rpt \
-              -rule   [ expr $ADK_WELL_TAP_INTERVAL/2 ]
+if {[info exists ADK_WELL_TAP_CELL] && [expr {$ADK_WELL_TAP_CELL ne ""}]} {
+  addWellTap -cell [list $ADK_WELL_TAP_CELL] \
+             -prefix       WELLTAP \
+             -cellInterval $ADK_WELL_TAP_INTERVAL \
+             -checkerboard
+  
+  verifyWellTap -cells [list $ADK_WELL_TAP_CELL] \
+                -report reports/welltap.rpt \
+                -rule   [ expr $ADK_WELL_TAP_INTERVAL/2 ]
+} else {
+  echo "Warning: mflowgen skipping well tap insertion because no well taps found in ADK"
+}
 
 


### PR DESCRIPTION
Skips welltap insertion if the welltap cell isn't defined in adk.tcl so that the default flow works out of the box for technologies that don't use welltaps.