### PR TITLE
Remove tech-specific dont_use commands from genus node

### DIFF
--- a/steps/cadence-genus-synthesis/scripts/compile.tcl
+++ b/steps/cadence-genus-synthesis/scripts/compile.tcl
@@ -10,11 +10,6 @@ uniquify $design_name
 # Obey flattening effort of mflowgen graph
 set_attribute auto_ungroup $auto_ungroup_val
 
-# FIXME technology specific
-set_attribute avoid true [get_lib_cells {*/E* */G* *D16* *D20* *D24* *D28* *D32* SDF* *DFM*}]
-# don't use Scan enable D flip flops
-set_attribute avoid true [get_lib_cells {*SEDF*}]
-
 syn_gen
 set_attr syn_map_effort high
 syn_map

--- a/steps/cadence-genus-synthesis/scripts/setup-session.tcl
+++ b/steps/cadence-genus-synthesis/scripts/setup-session.tcl
@@ -22,3 +22,7 @@ if {[file exists $vars(capTableFile)]} {
 set_attr hdl_flatten_complex_port true
 
 set_attr hdl_resolve_instance_with_libcell true
+
+if {[info exists ADK_DONT_USE_CELL_LIST]} {
+  set_attribute avoid true [get_lib_cells $ADK_DONT_USE_CELL_LIST]
+}

--- a/steps/synopsys-dc-synthesis/scripts/setup-session.tcl
+++ b/steps/synopsys-dc-synthesis/scripts/setup-session.tcl
@@ -159,4 +159,8 @@ set_app_var sh_new_variable_message false
 
 if {[info exists ::env(DC_EXIT_AFTER_SETUP)]} { set DC_SETUP_DONE true }
 
+# Accept list of don't use cells from ADK 
 
+if {[info exists ADK_DONT_USE_CELL_LIST]} {                       
+  set_dont_use [get_lib_cells $ADK_DONT_USE_CELL_LIST]
+}                                                                 


### PR DESCRIPTION
Changes the genus node to accept a list of "dont_use" cells from the adk, rather than hard-coding specific cells into the script. I can make a similar change to the DC node if you think this is a useful way of specifying dont_use cells.