### PR TITLE
Add param for setting environment variables before drc run

### DIFF
--- a/steps/mentor-calibre-drc/configure.yml
+++ b/steps/mentor-calibre-drc/configure.yml
@@ -24,6 +24,7 @@ outputs:
 #-------------------------------------------------------------------------
 
 commands:
+  - if [ -n "$drc_env_setup" ]; then source inputs/adk/$drc_env_setup; fi
   - envsubst < drc.runset.template > drc.runset
   - calibre -gui -drc -batch -runset drc.runset
   - mkdir -p outputs && cd outputs
@@ -38,6 +39,10 @@ parameters:
   design_name: undefined
   # Use the rule deck "inputs/adk/${drc_rule_deck}"
   drc_rule_deck: calibre-drc-block.rule
+  # Optional: if the technology accepts DRC params
+  # as environment variables, source this script
+  # to set environment variables before running.
+  drc_env_setup: undefined
 
 #-------------------------------------------------------------------------
 # Debug


### PR DESCRIPTION
Not sure if this is the best way to do this, but some technologies use environment variables to control which DRC checks are run. This PR provides and optional param to point to a script in the adk that sets these variables.