### PR TITLE
Drc env setup

### DIFF
--- a/steps/mentor-calibre-drc/configure.yml
+++ b/steps/mentor-calibre-drc/configure.yml
@@ -24,7 +24,7 @@ outputs:
 #-------------------------------------------------------------------------
 
 commands:
-  - if [ $drc_env_setup != 'undefined' ]; then source inputs/adk/{drc_env_setup}; fi
+  - if [ -f "inputs/adk/{drc_env_setup}" ]; then source inputs/adk/{drc_env_setup}; fi
   - envsubst < drc.runset.template > drc.runset
   - calibre -gui -drc -batch -runset drc.runset
   - mkdir -p outputs && cd outputs

--- a/steps/mentor-calibre-drc/configure.yml
+++ b/steps/mentor-calibre-drc/configure.yml
@@ -24,7 +24,7 @@ outputs:
 #-------------------------------------------------------------------------
 
 commands:
-  - if [ -n "$drc_env_setup" ]; then source inputs/adk/$drc_env_setup; fi
+  - if [ $drc_env_setup != 'undefined' ]; then source inputs/adk/{drc_env_setup}; fi
   - envsubst < drc.runset.template > drc.runset
   - calibre -gui -drc -batch -runset drc.runset
   - mkdir -p outputs && cd outputs

--- a/steps/mentor-calibre-drc/configure.yml
+++ b/steps/mentor-calibre-drc/configure.yml
@@ -24,6 +24,7 @@ outputs:
 #-------------------------------------------------------------------------
 
 commands:
+  - if [ -n "$drc_env_setup" ]; then source inputs/adk/$drc_env_setup; fi
   - envsubst < drc.runset.template > drc.runset
   - calibre -gui -drc -batch -runset drc.runset
   - mkdir -p outputs && cd outputs
@@ -38,6 +39,10 @@ parameters:
   design_name: undefined
   # Use the rule deck "inputs/adk/${drc_rule_deck}"
   drc_rule_deck: calibre-drc-block.rule
+  # Optional: if the technology accepts DRC params
+  # as environment variables, source this script
+  # to set environment variables before running.
+  drc_env_setup: undefined
 
 #-------------------------------------------------------------------------
 # Debug


### PR DESCRIPTION
Re-opening this with a fix. Some technologies use system environment variables in their DRC decks to set the various "knobs" (density checks vs no density, metal stack, etc.), so this PR allows the calibre node to support those in addition to those who set these knobs directly in the Calibre rule deck.