### PR TITLE
Add param to genus node for -defines when reading in rtl

### DIFF
--- a/steps/cadence-genus-synthesis/configure.yml
+++ b/steps/cadence-genus-synthesis/configure.yml
@@ -50,6 +50,7 @@ parameters:
   # with the same name but different definitions.
   uniquify_with_design_name: True
   flatten_effort: 0
+  read_hdl_defines: ""
   order:
     - designer-interface.tcl
     - setup-session.tcl

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -17,6 +17,7 @@ set clock_period               $::env(clock_period)
 set gate_clock                 $::env(gate_clock)
 set uniquify_with_design_name  $::env(uniquify_with_design_name)
 set flatten_effort             $::env(flatten_effort)
+set read_hdl_defines           $::env(read_hdl_defines)
 
 # Here we do a weird mapping from our DC flatten_effort to genus flatten_effort
 # flatten_effort=0 goes to no flattening

--- a/steps/cadence-genus-synthesis/scripts/read-design.tcl
+++ b/steps/cadence-genus-synthesis/scripts/read-design.tcl
@@ -4,7 +4,7 @@
 # Author : Alex Carsello
 # Date   : September 28, 2020
 
-read_hdl -sv [lsort [glob -directory inputs -type f *.v *.sv]]
+read_hdl -define {$read_hdl_defines} -sv [lsort [glob -directory inputs -type f *.v *.sv]]
 
 # Prevent backslashes from being prepended to signal names...
 # this causes SAIF files to be invalid...needs to be before elaboration.


### PR DESCRIPTION
Allows for defining verilog macros during synth without overriding the read-design.tcl script.