### PR TITLE
prevent name collisions in innovus merged stream out

### DIFF
--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -19,6 +19,7 @@ set merge_files \
 streamOut $vars(results_dir)/$vars(design)-merged.gds \
     -units 1000 \
     -mapFile $vars(gds_layer_map) \
+    -uniquifyCellNames \
     -merge $merge_files
                
 


### PR DESCRIPTION
Without this option, when we ran top-level DRC checks, we found metal geometry errors in lower-level blocks, even though those blocks were clean when we ran drc on them separately. This was caused by via cell name collisions when the lower-level block was merged into the top level gds.

-uniquifyCellNames prevents this.