### PR TITLE
Small changes to make dc and genus synth steps more general

### DIFF
--- a/designs/GcdUnit/construct-commercial-full.py
+++ b/designs/GcdUnit/construct-commercial-full.py
@@ -29,7 +29,8 @@ def construct():
     'adk'            : adk_name,
     'adk_view'       : adk_view,
     'topographical'  : True,
-    'saif_instance'  : 'GcdUnitTb/GcdUnit_inst'
+    'saif_instance'  : 'GcdUnitTb/GcdUnit_inst',
+    'use_dc'         : True
   }
 
   #-----------------------------------------------------------------------
@@ -52,7 +53,12 @@ def construct():
 
   info           = Step( 'info',                           default=True )
   constraints    = Step( 'constraints',                    default=True )
-  dc             = Step( 'synopsys-dc-synthesis',          default=True )
+
+  if parameters['use_dc']:
+      syn        = Step('synopsys-dc-synthesis',           default=True )
+  else:
+      syn        = Step('cadence-genus-synthesis',         default=True )
+
   iflow          = Step( 'cadence-innovus-flowsetup',      default=True )
   init           = Step( 'cadence-innovus-init',           default=True )
   power          = Step( 'cadence-innovus-power',          default=True )
@@ -92,7 +98,7 @@ def construct():
   g.add_step( info           )
   g.add_step( rtl            )
   g.add_step( constraints    )
-  g.add_step( dc             )
+  g.add_step( syn            )
   g.add_step( iflow          )
   g.add_step( init           )
   g.add_step( power          )
@@ -121,7 +127,7 @@ def construct():
 
   # Connect by name
 
-  g.connect_by_name( adk,            dc             )
+  g.connect_by_name( adk,            syn            )
   g.connect_by_name( adk,            iflow          )
   g.connect_by_name( adk,            init           )
   g.connect_by_name( adk,            power          )
@@ -137,14 +143,14 @@ def construct():
   g.connect_by_name( adk,            drc            )
   g.connect_by_name( adk,            lvs            )
 
-  g.connect_by_name( rtl,            dc             )
-  g.connect_by_name( constraints,    dc             )
+  g.connect_by_name( rtl,            syn            )
+  g.connect_by_name( constraints,    syn            )
 
-  g.connect_by_name( dc,             iflow          )
-  g.connect_by_name( dc,             init           )
-  g.connect_by_name( dc,             power          )
-  g.connect_by_name( dc,             place          )
-  g.connect_by_name( dc,             cts            )
+  g.connect_by_name( syn,            iflow          )
+  g.connect_by_name( syn,            init           )
+  g.connect_by_name( syn,            power          )
+  g.connect_by_name( syn,            place          )
+  g.connect_by_name( syn,            cts            )
 
   g.connect_by_name( iflow,          init           )
   g.connect_by_name( iflow,          power          )
@@ -178,7 +184,7 @@ def construct():
   g.connect_by_name( gdsmerge,       lvs            )
 
   g.connect_by_name( adk,            debugcalibre   )
-  g.connect_by_name( dc,             debugcalibre   )
+  g.connect_by_name( syn,            debugcalibre   )
   g.connect_by_name( iflow,          debugcalibre   )
   g.connect_by_name( signoff,        debugcalibre   )
   g.connect_by_name( drc,            debugcalibre   )
@@ -193,13 +199,13 @@ def construct():
   g.connect_by_name( vcs_sim,        power_est      )
 
   g.connect_by_name( adk,            verif_post_synth )
-  g.connect_by_name( dc,             verif_post_synth )
-  g.connect( rtl.o('design.v'), verif_post_synth.i('design.ref.v') )
-  g.connect( dc.o('design.v'), verif_post_synth.i('design.impl.v') )
+  g.connect_by_name( syn,            verif_post_synth )
+  g.connect( rtl.o('design.v'), verif_post_synth.i('design.ref.v')  )
+  g.connect( syn.o('design.v'), verif_post_synth.i('design.impl.v') )
 
   g.connect_by_name( adk,            verif_post_layout )
-  g.connect_by_name( dc,             verif_post_layout )
-  g.connect( dc.o('design.v'), verif_post_layout.i('design.ref.v') )
+  g.connect_by_name( syn,            verif_post_layout )
+  g.connect( syn.o('design.v'), verif_post_layout.i('design.ref.v') )
   g.connect( signoff.o('design.lvs.v'), verif_post_layout.i('design.impl.v') )
 
   #-----------------------------------------------------------------------

--- a/designs/GcdUnit/construct-commercial.py
+++ b/designs/GcdUnit/construct-commercial.py
@@ -29,6 +29,7 @@ def construct():
     'adk'            : adk_name,
     'adk_view'       : adk_view,
     'topographical'  : True,
+    'use_dc'         : True
   }
 
   #-----------------------------------------------------------------------
@@ -50,7 +51,12 @@ def construct():
 
   info         = Step( 'info',                          default=True )
   constraints  = Step( 'constraints',                   default=True )
-  dc           = Step( 'synopsys-dc-synthesis',         default=True )
+
+  if parameters['use_dc']:
+      syn      = Step('synopsys-dc-synthesis',          default=True )
+  else:
+      syn      = Step('cadence-genus-synthesis',        default=True )
+
   iflow        = Step( 'cadence-innovus-flowsetup',     default=True )
   placeroute   = Step( 'cadence-innovus-place-route',   default=True )
   genlibdb     = Step( 'synopsys-ptpx-genlibdb',        default=True )
@@ -66,7 +72,7 @@ def construct():
   g.add_step( info         )
   g.add_step( rtl          )
   g.add_step( constraints  )
-  g.add_step( dc           )
+  g.add_step( syn          )
   g.add_step( iflow        )
   g.add_step( placeroute   )
   g.add_step( genlibdb     )
@@ -81,15 +87,15 @@ def construct():
 
   # Connect by name
 
-  g.connect_by_name( rtl,         dc           )
-  g.connect_by_name( adk,         dc           )
-  g.connect_by_name( constraints, dc           )
+  g.connect_by_name( rtl,         syn          )
+  g.connect_by_name( adk,         syn          )
+  g.connect_by_name( constraints, syn          )
 
   g.connect_by_name( adk,         iflow        )
-  g.connect_by_name( dc,          iflow        )
+  g.connect_by_name( syn,         iflow        )
 
   g.connect_by_name( adk,         placeroute   )
-  g.connect_by_name( dc,          placeroute   )
+  g.connect_by_name( syn,         placeroute   )
   g.connect_by_name( iflow,       placeroute   )
 
   g.connect_by_name( placeroute,  genlibdb     )
@@ -108,7 +114,7 @@ def construct():
   g.connect_by_name( gdsmerge,    lvs          )
 
   g.connect_by_name( adk,         debugcalibre )
-  g.connect_by_name( dc,          debugcalibre )
+  g.connect_by_name( syn,         debugcalibre )
   g.connect_by_name( iflow,       debugcalibre )
   g.connect_by_name( placeroute,  debugcalibre )
   g.connect_by_name( drc,         debugcalibre )

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -56,7 +56,6 @@ set vars(adk_dir) inputs/adk
 
 set vars(libs_typical,timing) \
     [join "
-        $vars(adk_dir)/stdcells.lib
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells*.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
         [lsort [glob -nocomplain inputs/*tt*.lib]]
@@ -76,7 +75,6 @@ foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
 if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
     set vars(libs_bc,timing) \
         [join "
-            $vars(adk_dir)/stdcells-bc.lib
             [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
             [lsort [glob -nocomplain inputs/*ff*.lib]]
             [lsort [glob -nocomplain inputs/*FF*.lib]]
@@ -95,7 +93,6 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
     set vars(libs_wc,timing) \
         [join "
-            $vars(adk_dir)/stdcells-wc.lib
             [lsort [glob -nocomplain $vars(adk_dir)/*-wc*.lib]]
             [lsort [glob -nocomplain inputs/*ss*.lib]]
             [lsort [glob -nocomplain inputs/*SS*.lib]]
@@ -107,11 +104,9 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
 #-------------------------------------------------------------------------
 # LEF files
 
+# will grab rtk-tech.lef and stdcells*.lef
 set vars(lef_files) \
 [join "
-    $vars(adk_dir)/rtk-tech.lef
-    $vars(adk_dir)/stdcells.lef
-    [lsort [glob -nocomplain $vars(adk_dir)/stdcells*.lef]]
     [lsort [glob -nocomplain $vars(adk_dir)/*.lef]]
     [lsort [glob -nocomplain inputs/*.lef]]
 "]

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -57,9 +57,7 @@ set vars(adk_dir) inputs/adk
 set vars(libs_typical,timing) \
     [join "
         $vars(adk_dir)/stdcells.lib
-        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt.lib]]
-        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt.lib]]
-        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells*.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
         [lsort [glob -nocomplain inputs/*tt*.lib]]
         [lsort [glob -nocomplain inputs/*TT*.lib]]
@@ -79,10 +77,6 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
     set vars(libs_bc,timing) \
         [join "
             $vars(adk_dir)/stdcells-bc.lib
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/iocells-bc.lib]]
             [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
             [lsort [glob -nocomplain inputs/*ff*.lib]]
             [lsort [glob -nocomplain inputs/*FF*.lib]]
@@ -102,10 +96,7 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
     set vars(libs_wc,timing) \
         [join "
             $vars(adk_dir)/stdcells-wc.lib
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
+            [lsort [glob -nocomplain $vars(adk_dir)/*-wc*.lib]]
             [lsort [glob -nocomplain inputs/*ss*.lib]]
             [lsort [glob -nocomplain inputs/*SS*.lib]]
       "]
@@ -120,7 +111,7 @@ set vars(lef_files) \
 [join "
     $vars(adk_dir)/rtk-tech.lef
     $vars(adk_dir)/stdcells.lef
-    [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lef]]
+    [lsort [glob -nocomplain $vars(adk_dir)/stdcells*.lef]]
     [lsort [glob -nocomplain $vars(adk_dir)/*.lef]]
     [lsort [glob -nocomplain inputs/*.lef]]
 "]

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -104,9 +104,9 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
 #-------------------------------------------------------------------------
 # LEF files
 
-# will grab rtk-tech.lef and stdcells*.lef
 set vars(lef_files) \
 [join "
+    $vars(adk_dir)/rtk-tech.lef
     [lsort [glob -nocomplain $vars(adk_dir)/*.lef]]
     [lsort [glob -nocomplain inputs/*.lef]]
 "]

--- a/steps/synopsys-dc-synthesis/scripts/designer-interface.tcl
+++ b/steps/synopsys-dc-synthesis/scripts/designer-interface.tcl
@@ -65,7 +65,6 @@ set dc_extra_link_libraries     [join "
 # Interface to the ASIC design kit
 #-------------------------------------------------------------------------
 
-#set dc_milkyway_ref_libraries   $adk_dir/stdcells.mwlib
 set dc_milkyway_ref_libraries   [join "
                                     [lsort [glob -nocomplain $adk_dir/stdcells*.mwlib]]
                                 "]

--- a/steps/synopsys-dc-synthesis/scripts/designer-interface.tcl
+++ b/steps/synopsys-dc-synthesis/scripts/designer-interface.tcl
@@ -65,13 +65,18 @@ set dc_extra_link_libraries     [join "
 # Interface to the ASIC design kit
 #-------------------------------------------------------------------------
 
-set dc_milkyway_ref_libraries   $adk_dir/stdcells.mwlib
+#set dc_milkyway_ref_libraries   $adk_dir/stdcells.mwlib
+set dc_milkyway_ref_libraries   [join "
+                                    [lsort [glob -nocomplain $adk_dir/stdcells*.mwlib]]
+                                "]
 set dc_milkyway_tf              $adk_dir/rtk-tech.tf
 set dc_tluplus_map              $adk_dir/rtk-tluplus.map
 set dc_tluplus_max              $adk_dir/rtk-max.tluplus
 set dc_tluplus_min              $adk_dir/rtk-min.tluplus
 set dc_adk_tcl                  $adk_dir/adk.tcl
-set dc_target_libraries         stdcells.db
+set dc_target_libraries         [join "
+                                    [lsort [glob -nocomplain $adk_dir/stdcells*.db]]
+                                "]
 
 # Extra libraries
 
@@ -84,5 +89,3 @@ set dc_additional_search_path   $adk_dir
 set dc_reports_dir              reports
 set dc_results_dir              results
 set dc_alib_dir                 alib
-
-


### PR DESCRIPTION
- Changes hardcoded stdcell file names to stdcells* in designer_interface.tcl in the dc and genus synthesis steps to allow for getting all stdcell library files included
- Allows for easily switching between dc and genus in construct.py with a use_dc parameter in GcdUnit