### PR TITLE
Multi family stdcell libs

### DIFF
--- a/steps/cadence-genus-genlib/scripts/set_libs.tcl
+++ b/steps/cadence-genus-genlib/scripts/set_libs.tcl
@@ -28,7 +28,7 @@ if {[llength $list_libs_tt] > 0} {
     puts "INFO: Found typical-typical libraries:"
     foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
 } else {
-    puts "ERROR: No typical-typical library is found in ADK nor inputs"
+    puts "WARNING: No typical-typical library is found in ADK nor inputs"
 }
 
 #-------------------------------------------------------------------------

--- a/steps/cadence-genus-genlib/scripts/set_libs.tcl
+++ b/steps/cadence-genus-genlib/scripts/set_libs.tcl
@@ -11,41 +11,45 @@ set vars(adk_dir) inputs/adk
 #-------------------------------------------------------------------------
 # Typical-case libraries
 
-set vars(libs_typical,timing) \
+set list_libs_tt \
     [join "
-        $vars(adk_dir)/stdcells.lib
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/*-typical*.lib]]
         [lsort [glob -nocomplain inputs/*tt*.lib]]
         [lsort [glob -nocomplain inputs/*TT*.lib]]
-        "]
-puts "INFO: Found typical-typical libraries $vars(libs_typical,timing)"
-foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
+    "]
+
+if {[llength $list_libs_tt] > 0} {
+    set vars(libs_typical,timing) $list_libs_tt
+    puts "INFO: Found typical-typical libraries:"
+    foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
+} else {
+    puts "ERROR: No typical-typical library is found in ADK nor inputs"
+}
 
 #-------------------------------------------------------------------------
 # Best-case libraries
 # - Process: ff
 # - Voltage: highest
 # - Temperature: highest (temperature inversion at 28nm and below)
-# FIXME note this code repeats all the bc libraries in the list at
-# least twice, because of the extra '*-bc-*' pattern...is this intentional?
 
-if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
-    set vars(libs_bc,timing) \
-        [join "
-            $vars(adk_dir)/stdcells-bc.lib
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/iocells-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
-            [lsort [glob -nocomplain inputs/*ff*.lib]]
-            [lsort [glob -nocomplain inputs/*FF*.lib]]
-        "]
-  puts "INFO: Found fast-fast libraries $vars(libs_bc,timing)"
-  foreach L $vars(libs_bc,timing) { echo "L_FF    $L" }
+set list_libs_bc \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
+        [lsort [glob -nocomplain inputs/*ff*.lib]]
+        [lsort [glob -nocomplain inputs/*FF*.lib]]
+    "]
+
+if {[llength $list_libs_bc] > 0} {
+    set vars(libs_bc,timing) $list_libs_bc
+    puts "INFO: Found fast-fast libraries:"
+    foreach L $vars(libs_bc,timing) { echo "L_FF    $L" }
+} else {
+    puts "WARNING: No fast-fast library is found in ADK nor inputs"
 }
 
 #-------------------------------------------------------------------------
@@ -54,19 +58,19 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 # - Voltage: lowest
 # - Temperature: lowest (temperature inversion at 28nm and below)
 
-if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
-    set vars(libs_wc,timing) \
-        [join "
-            $vars(adk_dir)/stdcells-wc.lib
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
-            [lsort [glob -nocomplain inputs/*ss*.lib]]
-            [lsort [glob -nocomplain inputs/*SS*.lib]]
-      "]
-  puts "INFO: Found slow-slow libraries $vars(libs_wc,timing)"
-  foreach L $vars(libs_wc,timing) { echo "L_SS    $L" }
+set list_libs_wc \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/*-wc*.lib]]
+        [lsort [glob -nocomplain inputs/*ss*.lib]]
+        [lsort [glob -nocomplain inputs/*SS*.lib]]
+    "]
+
+if {[llength $list_libs_wc] > 0} {
+    set vars(libs_wc,timing) $list_libs_wc
+    puts "INFO: Found slow-slow libraries:"
+    foreach L $vars(libs_wc,timing) { echo "L_SS    $L" }
+} else {
+    puts "WARNING: No slow-slow library is found in ADK nor inputs"
 }
 
 #-------------------------------------------------------------------------

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -54,18 +54,27 @@ set vars(adk_dir) inputs/adk
 #-------------------------------------------------------------------------
 # Typical-case libraries
 
-set vars(libs_typical,timing) \
+# Note: For backward compatibility, keep the following postfix-free libraries:
+# stdcells.lib, stdcells-lvt.lib, stdcells-ulvt.lib, stdcells-pm.lib, iocells.lib
+set list_libs_tt \
     [join "
-        $vars(adk_dir)/stdcells.lib
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lib]]
         [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/*-typical*.lib]]
         [lsort [glob -nocomplain inputs/*tt*.lib]]
         [lsort [glob -nocomplain inputs/*TT*.lib]]
-        "]
-puts "INFO: Found typical-typical libraries $vars(libs_typical,timing)"
-foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
+    "]
+
+if {[llength $list_libs_tt] > 0} {
+    set vars(libs_typical,timing) $list_libs_tt
+    puts "INFO: Found typical-typical libraries:"
+    foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
+} else {
+    puts "ERROR: No typical-typical library is found in ADK nor inputs"
+}
 
 #-------------------------------------------------------------------------
 # Best-case libraries
@@ -75,20 +84,19 @@ foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
 # FIXME note this code repeats all the bc libraries in the list at
 # least twice, because of the extra '*-bc-*' pattern...
 
-if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
-    set vars(libs_bc,timing) \
-        [join "
-            $vars(adk_dir)/stdcells-bc.lib
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/iocells-bc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
-            [lsort [glob -nocomplain inputs/*ff*.lib]]
-            [lsort [glob -nocomplain inputs/*FF*.lib]]
-        "]
-  puts "INFO: Found fast-fast libraries $vars(libs_bc,timing)"
-  foreach L $vars(libs_bc,timing) { echo "L_FF    $L" }
+set list_libs_bc \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
+        [lsort [glob -nocomplain inputs/*ff*.lib]]
+        [lsort [glob -nocomplain inputs/*FF*.lib]]
+    "]
+
+if {[llength $list_libs_bc] > 0} {
+    set vars(libs_bc,timing) $list_libs_bc
+    puts "INFO: Found fast-fast libraries:"
+    foreach L $vars(libs_bc,timing) { echo "L_FF    $L" }
+} else {
+    puts "WARNING: No fast-fast library is found in ADK nor inputs"
 }
 
 #-------------------------------------------------------------------------
@@ -98,19 +106,19 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 # - Temperature: lowest (temperature inversion at 28nm and below)
 # FIXME is there a reason this only looks for iocells???
 
-if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
-    set vars(libs_wc,timing) \
-        [join "
-            $vars(adk_dir)/stdcells-wc.lib
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
-            [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
-            [lsort [glob -nocomplain inputs/*ss*.lib]]
-            [lsort [glob -nocomplain inputs/*SS*.lib]]
-      "]
-  puts "INFO: Found slow-slow libraries $vars(libs_wc,timing)"
-  foreach L $vars(libs_wc,timing) { echo "L_SS    $L" }
+set list_libs_wc \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/*-wc*.lib]]
+        [lsort [glob -nocomplain inputs/*ss*.lib]]
+        [lsort [glob -nocomplain inputs/*SS*.lib]]
+    "]
+
+if {[llength $list_libs_wc] > 0} {
+    set vars(libs_wc,timing) $list_libs_wc
+    puts "INFO: Found slow-slow libraries:"
+    foreach L $vars(libs_wc,timing) { echo "L_SS    $L" }
+} else {
+    puts "WARNING: No slow-slow library is found in ADK nor inputs"
 }
 
 #-------------------------------------------------------------------------
@@ -119,7 +127,7 @@ if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
 set vars(lef_files) \
 [join "
     $vars(adk_dir)/rtk-tech.lef
-    $vars(adk_dir)/stdcells.lef
+    [lsort [glob -nocomplain $vars(adk_dir)/stdcells.lef]]
     [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lef]]
     [lsort [glob -nocomplain $vars(adk_dir)/*.lef]]
     [lsort [glob -nocomplain inputs/*.lef]]

--- a/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
+++ b/steps/cadence-genus-synthesis/scripts/designer-interface.tcl
@@ -73,7 +73,7 @@ if {[llength $list_libs_tt] > 0} {
     puts "INFO: Found typical-typical libraries:"
     foreach L $vars(libs_typical,timing) { echo "L_TT    $L" }
 } else {
-    puts "ERROR: No typical-typical library is found in ADK nor inputs"
+    puts "WARNING: No typical-typical library is found in ADK nor inputs"
 }
 
 #-------------------------------------------------------------------------

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -88,7 +88,7 @@ set list_libs_tt \
 
 if {[llength $list_libs_tt] > 0} {
     set vars(libs_typical,timing) $list_libs_tt
-    puts "INFO: Found typical-typical libraries $vars(libs_typical,timing)"
+    puts "INFO: Found typical-typical libraries:"
     foreach L $vars(libs_typical,timing) { puts "L_TT    $L" }
 } else {
     puts "ERROR: No typical-typical library is found in ADK nor inputs"
@@ -110,7 +110,7 @@ set list_libs_bc \
 if {[llength $list_libs_bc] > 0} {
     set vars(libs_bc,timing) $list_libs_bc
     lappend vars(library_sets)  "libs_bc"
-    puts "INFO: Found fast-fast libraries $vars(libs_bc,timing)"
+    puts "INFO: Found fast-fast libraries:"
     foreach L $vars(libs_bc,timing) { puts "L_FF    $L" }
 } else {
     puts "WARNING: No fast-fast library is found in ADK nor inputs"
@@ -132,7 +132,7 @@ set list_libs_wc \
 if {[llength $list_libs_wc] > 0} {
     set vars(libs_wc,timing) $list_libs_wc
     lappend vars(library_sets)  "libs_wc"
-    puts "INFO: Found slow-slow libraries $vars(libs_wc,timing)"
+    puts "INFO: Found slow-slow libraries:"
     foreach L $vars(libs_wc,timing) { puts "L_SS    $L" }
 } else {
     puts "WARNING: No slow-slow library is found in ADK nor inputs"
@@ -140,7 +140,7 @@ if {[llength $list_libs_wc] > 0} {
 
 set vars(lef_files) [join "
                       $vars(adk_dir)/rtk-tech.lef
-                      $vars(adk_dir)/stdcells.lef
+                      [lsort [glob -nocomplain $vars(adk_dir)/stdcells.lef]]
                       [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lef]]
                       [lsort [glob -nocomplain $vars(adk_dir)/*.lef]]
                       [lsort [glob -nocomplain inputs/*.lef]]
@@ -609,6 +609,9 @@ if { $::env(express_flow) } {
 #  set vars(signoff,time_design_setup,skip) true
 #  set vars(signoff,time_design_hold,skip) true
 }
+
+# Tell Innovus not to use the cells defined in ADK
+set vars(dont_use_list) $ADK_DONT_USE_CELL_LIST
 
 # Allows user to override any of the defaults in this file
 if [file exists inputs/setup.tcl] {

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -91,7 +91,7 @@ if {[llength $list_libs_tt] > 0} {
     puts "INFO: Found typical-typical libraries:"
     foreach L $vars(libs_typical,timing) { puts "L_TT    $L" }
 } else {
-    puts "ERROR: No typical-typical library is found in ADK nor inputs"
+    puts "WARNING: No typical-typical library is found in ADK nor inputs"
 }
 
 # The best case is:

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -610,9 +610,6 @@ if { $::env(express_flow) } {
 #  set vars(signoff,time_design_hold,skip) true
 }
 
-# Tell Innovus not to use the cells defined in ADK
-set vars(dont_use_list) $ADK_DONT_USE_CELL_LIST
-
 # Allows user to override any of the defaults in this file
 if [file exists inputs/setup.tcl] {
   source inputs/setup.tcl

--- a/steps/cadence-innovus-flowsetup/setup.tcl
+++ b/steps/cadence-innovus-flowsetup/setup.tcl
@@ -74,15 +74,25 @@ source $vars(adk_dir)/adk.tcl
 
 set vars(library_sets)        "libs_typical"
 
-set vars(libs_typical,timing) [join "
-                                $vars(adk_dir)/stdcells.lib
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
-                                [lsort [glob -nocomplain inputs/*tt*.lib]]
-                                [lsort [glob -nocomplain inputs/*TT*.lib]]
-                              "]
+set list_libs_tt \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/iocells.lib]]
+        [lsort [glob -nocomplain $vars(adk_dir)/*-typical*.lib]]
+        [lsort [glob -nocomplain inputs/*tt*.lib]]
+        [lsort [glob -nocomplain inputs/*TT*.lib]]
+    "]
+
+if {[llength $list_libs_tt] > 0} {
+    set vars(libs_typical,timing) $list_libs_tt
+    puts "INFO: Found typical-typical libraries $vars(libs_typical,timing)"
+    foreach L $vars(libs_typical,timing) { puts "L_TT    $L" }
+} else {
+    puts "ERROR: No typical-typical library is found in ADK nor inputs"
+}
 
 # The best case is:
 #
@@ -90,18 +100,20 @@ set vars(libs_typical,timing) [join "
 # - Voltage: highest
 # - Temperature: highest (temperature inversion at 28nm and below)
 
-if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
-  set vars(libs_bc,timing)    [join "
-                                $vars(adk_dir)/stdcells-bc.lib
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-bc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-bc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-bc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/iocells-bc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
-                                [lsort [glob -nocomplain inputs/*ff*.lib]]
-                                [lsort [glob -nocomplain inputs/*FF*.lib]]
-                              "]
-  lappend vars(library_sets)  "libs_bc"
+set list_libs_bc \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/*-bc*.lib]]
+        [lsort [glob -nocomplain inputs/*ff*.lib]]
+        [lsort [glob -nocomplain inputs/*FF*.lib]]
+    "]
+
+if {[llength $list_libs_bc] > 0} {
+    set vars(libs_bc,timing) $list_libs_bc
+    lappend vars(library_sets)  "libs_bc"
+    puts "INFO: Found fast-fast libraries $vars(libs_bc,timing)"
+    foreach L $vars(libs_bc,timing) { puts "L_FF    $L" }
+} else {
+    puts "WARNING: No fast-fast library is found in ADK nor inputs"
 }
 
 # The worst case is:
@@ -110,17 +122,20 @@ if {[file exists $vars(adk_dir)/stdcells-bc.lib]} {
 # - Voltage: lowest
 # - Temperature: lowest (temperature inversion at 28nm and below)
 
-if {[file exists $vars(adk_dir)/stdcells-wc.lib]} {
-  set vars(libs_wc,timing)    [join "
-                                $vars(adk_dir)/stdcells-wc.lib
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-lvt-wc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-ulvt-wc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/stdcells-pm-wc.lib]]
-                                [lsort [glob -nocomplain $vars(adk_dir)/iocells-wc.lib]]
-                                [lsort [glob -nocomplain inputs/*ss*.lib]]
-                                [lsort [glob -nocomplain inputs/*SS*.lib]]
-                              "]
-  lappend vars(library_sets)  "libs_wc"
+set list_libs_wc \
+    [join "
+        [lsort [glob -nocomplain $vars(adk_dir)/*-wc*.lib]]
+        [lsort [glob -nocomplain inputs/*ss*.lib]]
+        [lsort [glob -nocomplain inputs/*SS*.lib]]
+    "]
+
+if {[llength $list_libs_wc] > 0} {
+    set vars(libs_wc,timing) $list_libs_wc
+    lappend vars(library_sets)  "libs_wc"
+    puts "INFO: Found slow-slow libraries $vars(libs_wc,timing)"
+    foreach L $vars(libs_wc,timing) { puts "L_SS    $L" }
+} else {
+    puts "WARNING: No slow-slow library is found in ADK nor inputs"
 }
 
 set vars(lef_files) [join "

--- a/steps/cadence-innovus-init/configure.yml
+++ b/steps/cadence-innovus-init/configure.yml
@@ -39,6 +39,7 @@ commands:
 parameters:
   order:
     - main.tcl
+    - dont-use.tcl
     - quality-of-life.tcl
     - floorplan.tcl
     - add-endcaps-welltaps.tcl

--- a/steps/cadence-innovus-init/configure.yml
+++ b/steps/cadence-innovus-init/configure.yml
@@ -38,6 +38,7 @@ commands:
 
 parameters:
   order:
+    - pre-init.tcl
     - main.tcl
     - dont-use.tcl
     - quality-of-life.tcl

--- a/steps/cadence-innovus-init/scripts/dont-use.tcl
+++ b/steps/cadence-innovus-init/scripts/dont-use.tcl
@@ -1,0 +1,23 @@
+#=========================================================================
+# dont-use.tcl
+#=========================================================================
+# Although the ADK_DONT_USE_CELL_LIST variable is already applied in the 
+# sythesis script, we also need to apply it here to ensure that the tool
+# won't use the cells in the list as buffers/inverters.
+# This is equivalent to setting the "dont_use_list" environment variable
+# in setup.tcl in cadence-innovus-flowsetup. However, the commands created
+# by Innovus-Foundation-Flow throw errors if a pattern is not found in the
+# loaded libraries. For example, a design that only uses normal-VT cells
+# will run into errors if a pattern for high-VT cells is specified in the
+# ADK_DONT_USE_CELL_LIST variable.
+# The solution is to implement the setDontUse here, which will only execute
+# the command on found cells.
+#
+# Author : 
+# Date   : 
+
+if {[info exists ADK_DONT_USE_CELL_LIST]} {
+    foreach_in_collection cell [get_lib_cells $ADK_DONT_USE_CELL_LIST] {
+        setDontUse [get_object_name $cell] true
+    }
+}

--- a/steps/cadence-innovus-init/scripts/pre-init.tcl
+++ b/steps/cadence-innovus-init/scripts/pre-init.tcl
@@ -1,0 +1,11 @@
+#=========================================================================
+# pre-init.tcl
+#=========================================================================
+# This is used to do some setup before the main initialization script.
+# For example, some layer map files need to be set first, otherwise the
+# initialization scripts will throw errors afterwards.
+
+# set the QRC-LEF layer map if it exists
+if {[file exists $vars(adk_dir)/pdk-qrc-lef.map]} {
+  setExtractRCMode -lefTechFileMap $vars(adk_dir)/pdk-qrc-lef.map
+}


### PR DESCRIPTION
This PR implements the following:

### Enable loading multi-family stdcell libraries
Originally, mflowgen requires that the ADK must have 1 main stdcell library that is called _stdcell.lib_. However, there are technologies that provides the stdcell libs in multiple families. For example: stdcell_base.lib, stdcell_lvl.lib, stdcell_pwm.lib. The original methods fail when it cannot find the main lib. The solution is to make the hardcoded stdcell lib name optional, and add more naming options, such as postfix-based library names for mflowgen to search. The new library loading mechanism is backward compatible and have been tested on existing flows.
### Add pre-init.tcl into _cadence-innovus-init_ node
Some technologies require setting up mapping files before initialization happens, for example, a QRC-LEF mapping file. If not set, innovus complains when it execute run_init.tcl. Here, we added a pre-init.tcl before executing the main init to handle this issue.
### Add dont-use.tcl into _cadence-innovus-init_ node
Originally, only synthesis nodes look for `ADK_DONT_USE_CELL_LIST` and set those attributes. However, we should also have these dont-use attributes set in P&R tool, otherwise the tool might use those problematic cells as inverters/buffers to fix timing.