### PR TITLE
Prioritize the use of user-defined power strategy if found in inputs

### DIFF
--- a/steps/cadence-innovus-power/scripts/main.tcl
+++ b/steps/cadence-innovus-power/scripts/main.tcl
@@ -6,38 +6,44 @@
 # Author : Christopher Torng
 # Date   : January 13, 2020
 
-#-------------------------------------------------------------------------
-# Implement power strategy
-#-------------------------------------------------------------------------
-# Older technologies use a single coarse power mesh, but more advanced
-# technologies often use a combination of a fine+coarse power mesh.
-#
-# Here we check the direction of M2 to decide which power strategy to use.
-
-if {[info exists ADK_BASE_LAYER_IDX]} {
-  set base_layer_idx $ADK_BASE_LAYER_IDX
+if {[ file exists inputs/power-strategy.tcl ]} {
+  #-------------------------------------------------------------------------
+  # Implement power strategy
+  #-------------------------------------------------------------------------
+  puts "Info: Using user-defined power strategy found in inputs"
+  source -verbose inputs/power-strategy.tcl
 } else {
-  set base_layer_idx 0
-}
+  #-------------------------------------------------------------------------
+  # Implement power strategy
+  #-------------------------------------------------------------------------
+  # Older technologies use a single coarse power mesh, but more advanced
+  # technologies often use a combination of a fine+coarse power mesh.
+  #
+  # Here we check the direction of M2 to decide which power strategy to use.
 
-set M2_direction [dbGet [dbGet head.layers.name [expr $base_layer_idx + 2] -p].direction]
-
-if { $M2_direction == "Vertical" } {
-  # Vertical M2 -- Use single power mesh strategy
-  puts "Info: Using coarse-only power mesh because M2 is vertical"
-  if {[ file exists inputs/power-strategy-singlemesh.tcl ]} {
-    source -verbose inputs/power-strategy-singlemesh.tcl
+  if {[info exists ADK_BASE_LAYER_IDX]} {
+    set base_layer_idx $ADK_BASE_LAYER_IDX
   } else {
-    source -verbose scripts/power-strategy-singlemesh.tcl
+    set base_layer_idx 0
   }
-} else {
-  # Horizontal M2 -- Use dual power mesh strategy
-  puts "Info: Using fine+coarse power mesh because M2 is horizontal"
-  if {[ file exists inputs/power-strategy-dualmesh.tcl ]} {
-    source -verbose inputs/power-strategy-dualmesh.tcl
+
+  set M2_direction [dbGet [dbGet head.layers.name [expr $base_layer_idx + 2] -p].direction]
+
+  if { $M2_direction == "Vertical" } {
+    # Vertical M2 -- Use single power mesh strategy
+    puts "Info: Using coarse-only power mesh because M2 is vertical"
+    if {[ file exists inputs/power-strategy-singlemesh.tcl ]} {
+      source -verbose inputs/power-strategy-singlemesh.tcl
+    } else {
+      source -verbose scripts/power-strategy-singlemesh.tcl
+    }
   } else {
-    source -verbose scripts/power-strategy-dualmesh.tcl
+    # Horizontal M2 -- Use dual power mesh strategy
+    puts "Info: Using fine+coarse power mesh because M2 is horizontal"
+    if {[ file exists inputs/power-strategy-dualmesh.tcl ]} {
+      source -verbose inputs/power-strategy-dualmesh.tcl
+    } else {
+      source -verbose scripts/power-strategy-dualmesh.tcl
+    }
   }
 }
-
-


### PR DESCRIPTION
This PR prioritize the use of user-defined power-strategy.tcl in the inputs. To ensure backward compatibility, it will use the legacy singlemesh/dualmesh if no power-strategy.tcl in found.