### PR TITLE
Make -units option configurable through ADK

### DIFF
--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -17,7 +17,6 @@ set merge_files \
     ]
 
 streamOut $vars(results_dir)/$vars(design)-merged.gds \
-    -units 1000 \
     -mapFile $vars(gds_layer_map) \
     -uniquifyCellNames \
     -merge $merge_files

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -6,6 +6,15 @@
 # Author : Christopher Torng
 # Date   : March 26, 2018
 
+if { [info exists ADK_DBU_PRECISION] } { 
+    set stream_out_units $ADK_DBU_PRECISION
+} else {
+    set stream_out_units 1000
+}
+
+streamOut $vars(results_dir)/$vars(design).gds.gz \
+    -units ${stream_out_units} \
+    -mapFile $vars(gds_layer_map)
 
 set merge_files \
     [concat \
@@ -13,34 +22,8 @@ set merge_files \
         [lsort [glob -nocomplain inputs/*.gds*]] \
     ]
 
-if { [info exists ADK_DBU_PRECISION] } { 
-    if { $ADK_DBU_PRECISION == "default" } {
-        streamOut $vars(results_dir)/$vars(design).gds.gz \
-            -mapFile $vars(gds_layer_map)
-
-        streamOut $vars(results_dir)/$vars(design)-merged.gds \
-            -mapFile $vars(gds_layer_map) \
-            -uniquifyCellNames \
-            -merge $merge_files
-    } else {
-        streamOut $vars(results_dir)/$vars(design).gds.gz \
-            -units $ADK_DBU_PRECISION \
-            -mapFile $vars(gds_layer_map)
-
-        streamOut $vars(results_dir)/$vars(design)-merged.gds \
-            -units $ADK_DBU_PRECISION \
-            -mapFile $vars(gds_layer_map) \
-            -uniquifyCellNames \
-            -merge $merge_files
-    }
-} else {
-    streamOut $vars(results_dir)/$vars(design).gds.gz \
-        -units 1000 \
-        -mapFile $vars(gds_layer_map)
-
-    streamOut $vars(results_dir)/$vars(design)-merged.gds \
-        -units 1000 \
-        -mapFile $vars(gds_layer_map) \
-        -uniquifyCellNames \
-        -merge $merge_files
-}
+streamOut $vars(results_dir)/$vars(design)-merged.gds \
+    -units ${stream_out_units} \
+    -mapFile $vars(gds_layer_map) \
+    -uniquifyCellNames \
+    -merge $merge_files

--- a/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
+++ b/steps/cadence-innovus-flowsetup/innovus-foundation-flow/custom-scripts/stream-out.tcl
@@ -6,9 +6,6 @@
 # Author : Christopher Torng
 # Date   : March 26, 2018
 
-streamOut $vars(results_dir)/$vars(design).gds.gz \
-    -units 1000 \
-    -mapFile $vars(gds_layer_map)
 
 set merge_files \
     [concat \
@@ -16,9 +13,34 @@ set merge_files \
         [lsort [glob -nocomplain inputs/*.gds*]] \
     ]
 
-streamOut $vars(results_dir)/$vars(design)-merged.gds \
-    -mapFile $vars(gds_layer_map) \
-    -uniquifyCellNames \
-    -merge $merge_files
-               
+if { [info exists ADK_DBU_PRECISION] } { 
+    if { $ADK_DBU_PRECISION == "default" } {
+        streamOut $vars(results_dir)/$vars(design).gds.gz \
+            -mapFile $vars(gds_layer_map)
 
+        streamOut $vars(results_dir)/$vars(design)-merged.gds \
+            -mapFile $vars(gds_layer_map) \
+            -uniquifyCellNames \
+            -merge $merge_files
+    } else {
+        streamOut $vars(results_dir)/$vars(design).gds.gz \
+            -units $ADK_DBU_PRECISION \
+            -mapFile $vars(gds_layer_map)
+
+        streamOut $vars(results_dir)/$vars(design)-merged.gds \
+            -units $ADK_DBU_PRECISION \
+            -mapFile $vars(gds_layer_map) \
+            -uniquifyCellNames \
+            -merge $merge_files
+    }
+} else {
+    streamOut $vars(results_dir)/$vars(design).gds.gz \
+        -units 1000 \
+        -mapFile $vars(gds_layer_map)
+
+    streamOut $vars(results_dir)/$vars(design)-merged.gds \
+        -units 1000 \
+        -mapFile $vars(gds_layer_map) \
+        -uniquifyCellNames \
+        -merge $merge_files
+}


### PR DESCRIPTION
This PR removes the `-units` argument in stream-out.tcl. This argument is used to specify the resolution for values in the GDSII file. 
Originally, this is hardcoded to be 1000, which makes some technologies with different unit run into DRC issues. By default, Innovus uses the unit defined in rtk-tech.lef if this argument is not provided. I think we should go by default to make it more technology-agnostic.