### PR TITLE
more sophisticated postcondition error check for genus

### DIFF
--- a/steps/cadence-genus-genlib/configure.yml
+++ b/steps/cadence-genus-genlib/configure.yml
@@ -56,6 +56,6 @@ postconditions:
 
   # Basic error checking
 
-  - assert 'error' not in File( 'logs/genus.log' )
+  - assert [x for x in File( 'logs/genus.log' ) if 'error' in x.lower() and not 'puts' in x and not 'echo' in x]
   - assert 'Unresolved references' not in File( 'logs/genus.log' )
   - assert 'Unable to resolve' not in File( 'logs/genus.log' )

--- a/steps/cadence-genus-synthesis/configure.yml
+++ b/steps/cadence-genus-synthesis/configure.yml
@@ -87,7 +87,7 @@ postconditions:
   # Basic error checking
 
   - assert 'Cannot resolve reference' not in File( 'logs/genus.log' )
-  - assert 'Error   :' not in File( 'logs/genus.log' )
+  - assert [x for x in File( 'logs/genus.log' ) if 'error' in x.lower() and not 'puts' in x and not 'echo' in x]
 
   # Sanity check that there is a clock in the constraints
 

--- a/steps/cadence-genus-synthesis/configure.yml
+++ b/steps/cadence-genus-synthesis/configure.yml
@@ -87,7 +87,7 @@ postconditions:
   # Basic error checking
 
   - assert 'Cannot resolve reference' not in File( 'logs/genus.log' )
-  - assert [x for x in File( 'logs/genus.log' ) if 'error' in x.lower() and not 'puts' in x and not 'echo' in x]
+  - assert 'Error   :' not in File( 'logs/genus.log' )
 
   # Sanity check that there is a clock in the constraints
 


### PR DESCRIPTION
Our current build flags an error because of a genus script with a command something like
```
if { $found_error } { puts "ERROR found an error" }   
```
The script is sourced with a "verbose" flag, so that the line gets echoed into the log verbatim, and our existing postcondition sees the word "ERROR" and it fails, even though the `puts` command never actually executes.
```
  - assert 'error' not in File( 'logs/genus.log' )
```

To solve this specific problem, I am proposing a slightly more sophisticated mechanism, that fails only if the error line does not contain the words "puts" or "echo":
```
- assert [x for x in File( 'logs/genus.log' ) if "error" in x.lower() and not "puts" in x and not "echo" in x]
```
I've tested this and it seems to work. You may remember that I also discussed this change in a recent email thread.
