### PR TITLE
Support multiple cell patterns for cell padding

### DIFF
--- a/nodes/cadence-innovus-place/scripts/setup-cellpad.tcl
+++ b/nodes/cadence-innovus-place/scripts/setup-cellpad.tcl
@@ -12,7 +12,9 @@
 # to them later on.
 
 if {[info exists ADK_CELLS_TO_BE_PADDED]} {
-  specifyCellPad $ADK_CELLS_TO_BE_PADDED $::env(cell_padding)
+  foreach cell_pattern $ADK_CELLS_TO_BE_PADDED {
+    specifyCellPad $cell_pattern $::env(cell_padding)
+  }
 }
 
 reportCellPad -file $vars(rpt_dir)/$vars(step).cellpad.rpt


### PR DESCRIPTION
If `ADK_CELLS_TO_BE_PADDED` contains multiple cell patterns, it may be defined as a Tcl list:

```
set ADK_CELLS_TO_BE_PADDED [list \
    *REG* \
    *DFF* \
    *SCAN* \
]
```

The existing implementation passes the entire list directly to specifyCellPad, causing Innovus to interpret it as a single wildcard string:

```
**WARN: (IMPSYC-756): Found no cell matching wildcard "*REG* *DFF* *SCAN*".
Added padding to 0 cells.
Total 0 cells have padding.
```

As a result, no cells receive padding.

This PR fixes the issue by iterating over each pattern in ADK_CELLS_TO_BE_PADDED and applying specifyCellPad separately. It continues to support the existing single-pattern case.